### PR TITLE
Add support for ZFS facts on GNU/Linux

### DIFF
--- a/lib/facter/facts/linux/zfs_featurenumbers.rb
+++ b/lib/facter/facts/linux/zfs_featurenumbers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    class ZfsFeaturenumbers
+      FACT_NAME = 'zfs_featurenumbers'
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::ZFS.resolve(:zfs_featurenumbers)
+        Facter::ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/linux/zfs_version.rb
+++ b/lib/facter/facts/linux/zfs_version.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    class ZfsVersion
+      FACT_NAME = 'zfs_version'
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::ZFS.resolve(:zfs_version)
+        Facter::ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/linux/zpool_featureflags.rb
+++ b/lib/facter/facts/linux/zpool_featureflags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    class ZpoolFeatureflags
+      FACT_NAME = 'zpool_featureflags'
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::Zpool.resolve(:zpool_featureflags)
+        Facter::ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/linux/zpool_featurenumbers.rb
+++ b/lib/facter/facts/linux/zpool_featurenumbers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    class ZpoolFeaturenumbers
+      FACT_NAME = 'zpool_featurenumbers'
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::Zpool.resolve(:zpool_featurenumbers)
+        Facter::ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/linux/zpool_version.rb
+++ b/lib/facter/facts/linux/zpool_version.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    class ZpoolVersion
+      FACT_NAME = 'zpool_version'
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::Zpool.resolve(:zpool_version)
+        Facter::ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -509,6 +509,11 @@ os_hierarchy.each do |os|
     require_relative '../../facts/linux/timezone'
     require_relative '../../facts/linux/virtual'
     require_relative '../../facts/linux/xen'
+    require_relative '../../facts/linux/zfs_featurenumbers'
+    require_relative '../../facts/linux/zfs_version'
+    require_relative '../../facts/linux/zpool_featureflags'
+    require_relative '../../facts/linux/zpool_featurenumbers'
+    require_relative '../../facts/linux/zpool_version'
 
     require_relative '../../resolvers/linux/docker_uptime'
     require_relative '../../resolvers/linux/hostname'

--- a/spec/facter/facts/linux/zfs_featurenumbers_spec.rb
+++ b/spec/facter/facts/linux/zfs_featurenumbers_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Facts::Linux::ZfsFeaturenumbers do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linux::ZfsFeaturenumbers.new }
+
+    let(:feature_numbers) { '1,2,3,4,5' }
+
+    before do
+      allow(Facter::Resolvers::ZFS).to receive(:resolve).with(:zfs_featurenumbers).and_return(feature_numbers)
+    end
+
+    it 'returns zfs_featurenumbers fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'zfs_featurenumbers', value: feature_numbers)
+    end
+  end
+end

--- a/spec/facter/facts/linux/zfs_version_spec.rb
+++ b/spec/facter/facts/linux/zfs_version_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Facts::Linux::ZfsVersion do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linux::ZfsVersion.new }
+
+    let(:version) { '6' }
+
+    before do
+      allow(Facter::Resolvers::ZFS).to receive(:resolve).with(:zfs_version).and_return(version)
+    end
+
+    it 'returns zfs_version fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'zfs_version', value: version)
+    end
+  end
+end

--- a/spec/facter/facts/linux/zpool_featureflags_spec.rb
+++ b/spec/facter/facts/linux/zpool_featureflags_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe Facts::Linux::ZpoolFeatureflags do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linux::ZpoolFeatureflags.new }
+
+    let(:zpool_feature_flags) { 'async_destroy,empty_bpobj,lz4_compress,multi_vdev_crash_dump,spacemap_histogram' }
+
+    before do
+      allow(Facter::Resolvers::Zpool).to \
+        receive(:resolve).with(:zpool_featureflags).and_return(zpool_feature_flags)
+    end
+
+    it 'returns the zpool_featureflags fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'zpool_featureflags', value: zpool_feature_flags)
+    end
+  end
+end

--- a/spec/facter/facts/linux/zpool_featurenumbers_spec.rb
+++ b/spec/facter/facts/linux/zpool_featurenumbers_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe Facts::Linux::ZpoolFeaturenumbers do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linux::ZpoolFeaturenumbers.new }
+
+    let(:zpool_featurenumbers) { '1,2,3,4,5,6,7' }
+
+    before do
+      allow(Facter::Resolvers::Zpool).to \
+        receive(:resolve).with(:zpool_featurenumbers).and_return(zpool_featurenumbers)
+    end
+
+    it 'returns the zpool_featurenumbers fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'zpool_featurenumbers', value: zpool_featurenumbers)
+    end
+  end
+end

--- a/spec/facter/facts/linux/zpool_version_spec.rb
+++ b/spec/facter/facts/linux/zpool_version_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Facts::Linux::ZpoolVersion do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linux::ZpoolVersion.new }
+
+    let(:version) { '5' }
+
+    before do
+      allow(Facter::Resolvers::Zpool).to receive(:resolve).with(:zpool_version).and_return(version)
+    end
+
+    it 'returns the ZPool version fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'zpool_version', value: version)
+    end
+  end
+end


### PR DESCRIPTION
OpenZFS can be installed on Linux nodes, and is packaged in some Linux distros such as Debian, so it makes sense to make these facts available when the system has support for ZFS.

This patch was created by copying the FreeBSD code and adjusting the namespaces, and tested successfully on a Debian 12 node.

Originally submitted as:
https://github.com/puppetlabs/facter/pull/2782
