### PR TITLE
Fix resolution of the `virtual` fact on FreeBSD

### DIFF
--- a/lib/facter/util/facts/posix/virtual_detector.rb
+++ b/lib/facter/util/facts/posix/virtual_detector.rb
@@ -16,10 +16,14 @@ module Facter
             private
 
             def check_docker_lxc
+              return unless Object.const_defined?('Facter::Resolvers::Linux::Containers')
+
               Facter::Resolvers::Linux::Containers.resolve(:vm)
             end
 
             def check_gce
+              return unless Object.const_defined?('Facter::Resolvers::Linux::DmiBios')
+
               bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
               'gce' if bios_vendor&.include?('Google')
             end
@@ -61,6 +65,8 @@ module Facter
             end
 
             def check_other_facts
+              return unless Object.const_defined?('Facter::Resolvers::Linux::DmiBios')
+
               bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
               return 'kvm' if bios_vendor&.include?('Amazon EC2')
 


### PR DESCRIPTION
We should not call Linux-specific code from a non-Linux system. Before #15, the Linux-specific code was unexpectedly loaded, and the Linux resolver was non-functional on FreeBSD, causing a warning to be output. With #15, the Linux specific code is not loaded anymore, breaking further the fact resolution.

In order to fix this, the virtual_detector code needs to either be split into platform-specific pieces, or take care to only call platform-specific code on these platforms. Given this is a utility class, I chose the second route, and since the Linux-specific code is now only loaded on Linux, rely on the namespace existing or not to determine if we should run that code.

Originally submitted as:
https://github.com/puppetlabs/facter/pull/2744
