### PR TITLE
Match class & file name for Solaris Filesystems

### DIFF
--- a/lib/facter/facts/solaris/filesystems.rb
+++ b/lib/facter/facts/solaris/filesystems.rb
@@ -6,7 +6,7 @@ module Facts
       FACT_NAME = 'filesystems'
 
       def call_the_resolver
-        fact_value = Facter::Resolvers::Solaris::Filesystem.resolve(:file_systems)
+        fact_value = Facter::Resolvers::Solaris::Filesystems.resolve(:file_systems)
         Facter::ResolvedFact.new(FACT_NAME, fact_value)
       end
     end

--- a/lib/facter/resolvers/solaris/filesystems.rb
+++ b/lib/facter/resolvers/solaris/filesystems.rb
@@ -3,7 +3,7 @@
 module Facter
   module Resolvers
     module Solaris
-      class Filesystem < BaseResolver
+      class Filesystems < BaseResolver
         init_resolver
 
         class << self

--- a/spec/facter/facts/solaris/filesystems_spec.rb
+++ b/spec/facter/facts/solaris/filesystems_spec.rb
@@ -7,7 +7,7 @@ describe Facts::Solaris::Filesystems do
     let(:files) { 'apfs,autofs,devfs' }
 
     before do
-      allow(Facter::Resolvers::Solaris::Filesystem).to \
+      allow(Facter::Resolvers::Solaris::Filesystems).to \
         receive(:resolve).with(:file_systems).and_return(files)
     end
 

--- a/spec/facter/resolvers/solaris/filesystems_spec.rb
+++ b/spec/facter/resolvers/solaris/filesystems_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-describe Facter::Resolvers::Solaris::Filesystem do
-  subject(:filesystems_resolver) { Facter::Resolvers::Solaris::Filesystem }
+describe Facter::Resolvers::Solaris::Filesystems do
+  subject(:filesystems_resolver) { Facter::Resolvers::Solaris::Filesystems }
 
   let(:filesystems) { 'hsfs,nfs,pcfs,udfs,ufs' }
 


### PR DESCRIPTION
The filename was plural but the class name was inconsistently singular.
Other resolvers / facts seems to consistently use plural, so pluralize
the class name ta match the file name.
