### PR TITLE
Detect Windows Server 2025

### DIFF
--- a/lib/facter/util/facts/windows_release_finder.rb
+++ b/lib/facter/util/facts/windows_release_finder.rb
@@ -25,15 +25,22 @@ module Facter
           def check_version_10_11(consumerrel, kernel_version)
             build_number = kernel_version[/([^.]*)$/].to_i
 
-            return '11' if build_number >= 22_000
-            return '10' if consumerrel
-
-            if build_number >= 20_348
-              '2022'
-            elsif build_number >= 17_623
-              '2019'
+            if consumerrel
+              if build_number >= 22_000
+                '11'
+              else
+                '10'
+              end
             else
-              '2016'
+              if build_number >= 26_100
+                '2025'
+              elsif build_number >= 20_348
+                '2022'
+              elsif build_number >= 17_623
+                '2019'
+              else
+                '2016'
+              end
             end
           end
 

--- a/lib/facter/util/facts/windows_release_finder.rb
+++ b/lib/facter/util/facts/windows_release_finder.rb
@@ -31,16 +31,14 @@ module Facter
               else
                 '10'
               end
+            elsif build_number >= 26_100
+              '2025'
+            elsif build_number >= 20_348
+              '2022'
+            elsif build_number >= 17_623
+              '2019'
             else
-              if build_number >= 26_100
-                '2025'
-              elsif build_number >= 20_348
-                '2022'
-              elsif build_number >= 17_623
-                '2019'
-              else
-                '2016'
-              end
+              '2016'
             end
           end
 

--- a/spec/facter/util/facts/windows_release_finder_spec.rb
+++ b/spec/facter/util/facts/windows_release_finder_spec.rb
@@ -36,6 +36,17 @@ describe Facter::Util::Facts::WindowsReleaseFinder do
     end
   end
 
+  describe '#find windows release when version is 2025' do
+    let(:cons) { false }
+    let(:desc) {}
+    let(:k_version) { '10.0.26100' }
+    let(:version) { '10.0' }
+
+    it 'returns 2025' do
+      expect(Facter::Util::Facts::WindowsReleaseFinder.find_release(input)).to eql('2025')
+    end
+  end
+
   describe '#find windows release when version is 2022' do
     let(:cons) { false }
     let(:desc) {}


### PR DESCRIPTION
adding build number of Windows Server 2025 and fixed consumer release logic in windows_release_finder.rb

(previously, Windows Server 2025 was detected as consumer Windows 11...)
