### PR TITLE
Lower the version of the gem

### DIFF
--- a/lib/facter/version.rb
+++ b/lib/facter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Facter
-  VERSION = '4.11.0' unless defined?(VERSION)
+  VERSION = '4.11.0.rc1' unless defined?(VERSION)
 end

--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'openfact'
-  spec.version       = '4.11.0'
+  spec.version       = '4.11.0.rc1'
   spec.authors       = ['OpenVox Project']
   spec.email         = ['openvox@voxpupuli.org']
   spec.homepage      = 'https://github.com/OpenVoxProject/openfact/'


### PR DESCRIPTION
The Perforce / PuppetLabs tooling bumped the version of gems to the next
minor version when releasing a version, while at Vox Pupuli we usually
bump the patch version and add a `.rc1` to make sure version never go
backwards.

Adopt this scheme by lowering the gem version before we release it for
the first time.

4.11.0.rc1 is before 4.11.0.
