### PR TITLE
Gemfile: Add faraday-retry for release group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemspec
 
 group(:release, optional: true) do
-  gem 'github_changelog_generator'
+  gem 'faraday-retry', '~> 2.1', require: false
+  gem 'github_changelog_generator', '~> 1.16.4', require: false
 end
 
 gem 'packaging', require: false


### PR DESCRIPTION
this is an optional GCG dependency, without it we get a warning. In other gems we include it as well.