### PR TITLE
Add os.support.end fact using os-release

### DIFF
--- a/lib/facter/facts/linux/os/support.rb
+++ b/lib/facter/facts/linux/os/support.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    module Os
+      class Support
+        FACT_NAME = 'os.support'
+
+        def call_the_resolver
+          # https://www.freedesktop.org/software/systemd/man/latest/os-release.html#SUPPORT_END=
+          support_end = Facter::Resolvers::OsRelease.resolve(:support_end)
+
+          return unless support_end
+
+          [Facter::ResolvedFact.new(FACT_NAME, end: support_end)]
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -484,6 +484,7 @@ os_hierarchy.each do |os|
     require_relative '../../facts/linux/os/selinux/enabled'
     require_relative '../../facts/linux/os/selinux/enforced'
     require_relative '../../facts/linux/os/selinux/policy_version'
+    require_relative '../../facts/linux/os/support'
     require_relative '../../facts/linux/partitions'
     require_relative '../../facts/linux/path'
     require_relative '../../facts/linux/processor'


### PR DESCRIPTION
The SUPPORT_END variable in os-release was added in systemd 252. Quoting the manpage:

> The date at which support for this version of the OS ends. (What
> exactly "lack of support" means varies between vendors, but generally
> users should assume that updates, including security fixes, will not be
> provided.) The value is a date in the ISO 8601 format "YYYY-MM-DD", and
> specifies the first day on which support is not provided.

Link: https://www.freedesktop.org/software/systemd/man/latest/os-release.html#SUPPORT_END=