### PR TITLE
Replace Windows 2019->2022 runners

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
           - ubuntu-22.04
           - ubuntu-24.04

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -27,8 +27,8 @@ jobs:
           - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
           - {os: ubuntu-22.04, ruby: 'jruby-9.3.14.0'}
           - {os: ubuntu-latest, ruby: 'jruby-9.4.8.0'}
-          - {os: windows-2019, ruby: '2.7'}
-          - {os: windows-2019, ruby: '3.2'} # with openssl 3
+          - {os: windows-2022, ruby: '2.7'}
+          - {os: windows-2022, ruby: '3.2'} # with openssl 3
     runs-on: ${{ matrix.cfg.os }}
     env:
       BUNDLE_SET: 'with integration'


### PR DESCRIPTION
Windows 2019 runners are EoL.