### PR TITLE
Update logger dependency version constraint

### DIFF
--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -48,6 +48,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'base64', '>= 0.1', '< 0.4'
   spec.add_runtime_dependency 'hocon', '~> 1.3'
-  spec.add_runtime_dependency 'logger', '>= 1.5'
+  spec.add_runtime_dependency 'logger', '~> 1.5'
   spec.add_runtime_dependency 'thor', ['>= 1.0.1', '< 2']
 end


### PR DESCRIPTION
Putting this at 1.7 put it past the version shipped with Ruby 3.2.9 by default. Since we don't specifically need things in 1.7, to avoid shipping our own logger gem, this relaxes it back to 1.5+.