### PR TITLE
Remove `--without` from bundler call

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -135,7 +135,8 @@ def verify_facter_standalone_exits_0
     # `documentation` group contains ronn and hpricot
     # both gems are ancient, dead upstream, don't compile on modern rubies
     # and are only required for building manpages
-    run('bundle install --without development:documentation')
+    run('bundle config set --local without "development documentation"')
+    run('bundle install')
     run('bundle exec facter')
   end
 end


### PR DESCRIPTION
This parameter got removed in a recent release.