### PR TITLE
Fix facter networking on OpenBSD with gif or gre tunnel interfaces

### DIFF
--- a/lib/facter/util/resolvers/networking/networking.rb
+++ b/lib/facter/util/resolvers/networking/networking.rb
@@ -118,6 +118,7 @@ module Facter
           def expand_binding(values, bindings, ipv4_type: true)
             binding = find_valid_binding(bindings)
             return unless binding.is_a?(Hash) && binding[:address]
+
             ip_protocol_type = ipv4_type ? '' : '6'
 
             values["ip#{ip_protocol_type}".to_sym] = binding[:address]


### PR DESCRIPTION
when there's a gif or gre tunnel interface configured, issue happens.

Today I updated a way out of date box, which prior to update ran puppet and facter.
Now with openfact, it broke, with a  tunnel interface like this:

```
gif0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1280
        description: Tunnel to HE
        index 14 priority 0 llprio 3
        encap: txprio payload rxprio payload
        groups: gif egress
        tunnel: inet 192.168.178.21 --> 16.6.6.14 ttl 64 nodf ecn
        inet6 fe80::227c:14ff:fef0:1321%gif0 -->  prefixlen 64 scopeid 0xe
        inet6 2001:470:6c:b1d::2 --> 2001:470:6c:b1d::1 prefixlen 128
```

the 192.168.178.21 is the IP of my egress device, and there is properly shows up as binding, but it's right to not show up here as binding.

when running facter networking, causes errors and output like:
```
[2025-12-25 16:40:52.677247 ] ERROR Facter::Resolvers::Networking - Resolving fact interfaces, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.696152 ] ERROR Facter::Resolvers::Networking - Resolving fact ip, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.725688 ] ERROR Facter::Resolvers::Networking - Resolving fact ip6, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.745391 ] ERROR Facter::Resolvers::Networking - Resolving fact mac, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.766091 ] ERROR Facter::Resolvers::Networking - Resolving fact mtu, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.785599 ] ERROR Facter::Resolvers::Networking - Resolving fact netmask, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.805273 ] ERROR Facter::Resolvers::Networking - Resolving fact netmask6, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.834451 ] ERROR Facter::Resolvers::Networking - Resolving fact network, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.855094 ] ERROR Facter::Resolvers::Networking - Resolving fact network6, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.875560 ] ERROR Facter::Resolvers::Networking - Resolving fact scope6, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
[2025-12-25 16:40:52.900617 ] ERROR Facter::Resolvers::Openbsd::Dhcp - Resolving fact dhcp, but got undefined method '[]' for nil at /usr/local/lib/ruby/gems/3.4/gems/openfact-5.2.1/lib/facter/util/resolvers/networking/networking.rb:65:in 'block in Facter::Util::Resolvers::Networking.find_valid_binding'
{
  domain => "mydomain.com",
  fqdn => "myhost.mydomain.com",
  hostname => "myhost",
  primary => "em0"
}
```

With patch below, facter networking.interfaces.gif0 looks like this:

```
sudo facter networking.interfaces.gif0
{
  bindings => [
    null
  ],
  bindings6 => [
    {
      address => "fe80::227c:14ff:fef0:1321",
      netmask => "ffff:ffff:ffff:ffff::",
      network => "fe80::",
      scope6 => "link"
    },
    {
      address => "2001:470:6c:b1d::2",
      netmask => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
      network => "2001:470:6c:b1d::2",
      scope6 => "global"
    }
  ],
  ip6 => "2001:470:6c:b1d::2",
  mtu => 1280,
  netmask6 => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
  network6 => "2001:470:6c:b1d::2",
  scope6 => "global"
}
```

Issue seen with openfact 5.2.0 and 5.2.1.


No idea if the fix is the right approach, any feedback appreciated

