### PR TITLE
Detect QEMU and Yandex hypervisors to yield correct {is_,}virtual facts

### DIFF
--- a/lib/facter/resolvers/openbsd/virtual.rb
+++ b/lib/facter/resolvers/openbsd/virtual.rb
@@ -10,9 +10,11 @@ module Facter
           # :model
 
           VM_GUEST_SYSCTL_NAMES = {
+            'QEMU' => 'qemu',
             'VMM' => 'vmm',
-            'vServer' => 'vserver',
+            'Yandex' => 'yandex',
             'oracle' => 'virtualbox',
+            'vServer' => 'vserver',
             'xen' => 'xenu',
             'none' => nil
           }.freeze
@@ -24,17 +26,23 @@ module Facter
           end
 
           CTL_HW = 6
+          HW_VENDOR  = 14
           HW_PRODUCT = 15
 
           def read_facts(fact_name)
             require 'facter/resolvers/bsd/ffi/ffi_helper'
 
             vm = Facter::Bsd::FfiHelper.sysctl(:string, [CTL_HW, HW_PRODUCT])
-            vm = if VM_GUEST_SYSCTL_NAMES.key?(vm)
-                   VM_GUEST_SYSCTL_NAMES[vm]
-                 else
-                   'physical'
-                 end
+            if VM_GUEST_SYSCTL_NAMES.key?(vm)
+              vm = VM_GUEST_SYSCTL_NAMES[vm]
+            else
+              vm = Facter::Bsd::FfiHelper.sysctl(:string, [CTL_HW, HW_VENDOR])
+              vm = if VM_GUEST_SYSCTL_NAMES.key?(vm)
+                     VM_GUEST_SYSCTL_NAMES[vm]
+                   else
+                     'physical'
+                   end
+            end
             @fact_list[:vm] = vm
             @fact_list[fact_name]
           end


### PR DESCRIPTION
On OpenBSD, the `hw.product` sysctl(2) is used to detect, i.e. detect,
whether the system is virtual or "physical".

Some hypervisors, however, provide the relevant bits via `hw.vendor`,
so check that as fallback in case the product string does not match.

Fix #61.
