### PR TITLE
Drop Ruby 2.5 / 2.6 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - acceptance/**/*
     - vendor/**/*

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -85,3 +85,16 @@ Style/Documentation:
 Style/OptionalBooleanParameter:
   Exclude:
     - 'lib/facter/util/resolvers/http.rb'
+
+# Offense count: 13
+# This cop supports unsafe autocorrection (--autocorrect-all).
+Style/SlicingWithRange:
+  Exclude:
+    - 'install.rb'
+    - 'lib/facter/facts/solaris/ldom.rb'
+    - 'lib/facter/framework/cli/cli.rb'
+    - 'lib/facter/resolvers/aix/serialnumber.rb'
+    - 'lib/facter/resolvers/freebsd/swap_memory.rb'
+    - 'lib/facter/resolvers/networking.rb'
+    - 'lib/facter/resolvers/partitions.rb'
+    - 'lib/facter/util/api_debugger.rb'

--- a/lib/docs/generate.rb
+++ b/lib/docs/generate.rb
@@ -18,11 +18,7 @@ def format_facts(fact_hash)
                            facts: fact_hash
                          })
 
-  erb = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
-          ERB.new(File.read(PATH_TO_TEMPLATE), trim_mode: '-')
-        else
-          ERB.new(File.read(PATH_TO_TEMPLATE), nil, '-')
-        end
+  erb = ERB.new(File.read(PATH_TO_TEMPLATE), trim_mode: '-')
   erb.result(scope.instance_eval { binding })
 end
 

--- a/lib/facter/framework/cli/cli.rb
+++ b/lib/facter/framework/cli/cli.rb
@@ -113,7 +113,7 @@ module Facter
       negate_options = %w[block cache custom_facts external_facts]
 
       template = File.join(File.dirname(__FILE__), '..', '..', 'templates', 'man.erb')
-      erb = ERB.new(File.read(template), nil, '-')
+      erb = ERB.new(File.read(template), trim_mode: '-')
       erb.filename = template
       puts erb.result(binding)
     end

--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   base = "#{__dir__}#{File::SEPARATOR}"
   spec.files = dirs.map { |path| path.sub(base, '') }
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.7'
   spec.bindir = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
In the past CI was adjusted to Require Ruby 2.7 or newer, but we didn't drop the old versions from the gemspec. While it claims to support Ruby 2.5 & 2.6, it doesn't work in reality. This changes fixes this.

Ruby 2.5 was used in puppet AIO 6 / and jruby 9.3 (compatible with Ruby 2.6) in puppetserver 7. Both are EoL since ages.