### PR TITLE
CI: Add jruby-9.4.12.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
           - '3.3'
           - '3.4'
           - '4.0'
+          - 'jruby-9.4.12.1'
           - 'jruby-9.4.8.0'
     runs-on: ubuntu-24.04
     steps:
@@ -142,6 +143,7 @@ jobs:
           - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
           - {os: ubuntu-22.04, ruby: 'jruby-9.3.14.0'}
           - {os: ubuntu-latest, ruby: 'jruby-9.4.8.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.4.12.1'}
           - {os: windows-2022, ruby: '2.7'}
           - {os: windows-2022, ruby: '3.2'} # with openssl 3
     runs-on: ${{ matrix.cfg.os }}

--- a/spec/facter/util/resolvers/networking/networking_spec.rb
+++ b/spec/facter/util/resolvers/networking/networking_spec.rb
@@ -54,7 +54,9 @@ describe Facter::Util::Resolvers::Networking do
       let(:address) { '::ffff:192.0.2.128' }
 
       it 'returns scope6' do
-        pending('JRuby 9.4.7.0 does not properly parse mixed IPv6 addresses https://github.com/jruby/jruby/issues/8248') if RUBY_PLATFORM == 'java' && RUBY_VERSION == '3.1.4'
+        # openvoxserver 8.12 ships jruby 9.4.12. older versions used 9.4.8, puppetserver 8 used 9.4.7.
+        # The jruby bug is fixed in 9.4.12
+        pending('JRuby 9.4.7.0 does not properly parse mixed IPv6 addresses https://github.com/jruby/jruby/issues/8248') if defined?(JRUBY_VERSION) && JRUBY_VERSION == '9.4.8.0'
         expect(networking_helper.get_scope(address)).to eql('global')
       end
     end


### PR DESCRIPTION
This is the new target version for openvoxserver/db 8: https://github.com/OpenVoxProject/jruby-deps/blob/a50c718fee1a3df385959cf02dd4b61503b53472/project.clj#L1