### PR TITLE
Don't run dhcpcd command when it isn't running

### DIFF
--- a/lib/facter/util/linux.rb
+++ b/lib/facter/util/linux.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Facter
+  module Util
+    module Linux
+      def self.process_running?(process_name)
+        pidfiles = Dir.glob("{/run,/var/run}/#{process_name}{,*,/}*.pid")
+        pidfiles.each do |pf|
+          next unless File.file?(pf)
+
+          pid = begin
+            Integer(Facter::Util::FileHelper.safe_read(pf, '').strip, 10)
+          rescue StandardError
+            nil
+          end
+          next unless pid&.positive?
+
+          begin
+            # Doesn't actually kill, just detects if the process exists
+            Process.kill(0, pid)
+            return true if proc_comm(pid) == process_name || proc_cmdline(pid)&.match?(%r{(^|\s|/)#{process_name}(\s|$)})
+          rescue Errno::ESRCH
+            # If we can't confirm identity, still treat it as not running to be safe.
+            next
+          rescue Errno::EPERM
+            # Exists but we can't inspect it; assume it's running.
+            return true
+          end
+        end
+
+        # Fallback: Try to find it in /proc
+        return false unless Dir.exist?('/proc')
+
+        Dir.glob('/proc/[0-9]*/comm').any? do |path|
+          Facter::Util::FileHelper.safe_read(path, nil)&.strip == process_name
+        end
+      end
+
+      def self.proc_comm(pid)
+        Facter::Util::FileHelper.safe_read("/proc/#{pid}/comm", nil)&.strip
+      end
+
+      def self.proc_cmdline(pid)
+        raw = Facter::Util::FileHelper.safe_read("/proc/#{pid}/cmdline", nil)
+        raw&.tr("\0", ' ')
+      end
+    end
+  end
+end

--- a/spec/facter/util/linux/dhcp_spec.rb
+++ b/spec/facter/util/linux/dhcp_spec.rb
@@ -115,6 +115,8 @@ describe Facter::Util::Linux::Dhcp do
         allow(File).to receive(:readable?).with('/var/lib/dhcp3/').and_return(false)
         allow(File).to receive(:readable?).with('/var/lib/NetworkManager/').and_return(false)
         allow(File).to receive(:readable?).with('/var/db/').and_return(false)
+        allow(Dir).to receive(:glob).with('{/run,/var/run}/dhcpcd{,*,/}*.pid').and_return([])
+        allow(Dir).to receive(:glob).with('/proc/[0-9]*/comm').and_return([])
 
         allow(Facter::Core::Execution).to receive(:which)
           .with('dhcpcd').and_return('/usr/bin/dhcpcd')


### PR DESCRIPTION
As noted in https://github.com/puppetlabs/facter/issues/2780, we try running dhcpcd commands when it isn't actually running, which on Ubuntu 24.04 at least ends up with a lot of spam noting this. Additionally, there's really no reason to do this on the loopback interface. This checks in as robust a way as possible to see not only that the dhcpcd command is availabe, but that it's actually running before attempting to run it.