### PR TITLE
Report SMT aware processors count on OpenBSD

### DIFF
--- a/lib/facter/facts/openbsd/processors/count.rb
+++ b/lib/facter/facts/openbsd/processors/count.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Openbsd
+    module Processors
+      class Count
+        FACT_NAME = 'processors.count'
+
+        def call_the_resolver
+          fact_value = Facter::Resolvers::Openbsd::Processors.resolve(:online_count)
+          Facter::ResolvedFact.new(FACT_NAME, fact_value)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -709,6 +709,7 @@ os_hierarchy.each do |os|
     require_relative '../../facts/openbsd/os/hardware'
     require_relative '../../facts/openbsd/os/name'
     require_relative '../../facts/openbsd/os/release'
+    require_relative '../../facts/openbsd/processors/count'
     require_relative '../../facts/openbsd/processors/isa'
     require_relative '../../facts/openbsd/ruby/platform'
     require_relative '../../facts/openbsd/ruby/sitedir'
@@ -721,6 +722,7 @@ os_hierarchy.each do |os|
     require_relative '../../resolvers/openbsd/dhcp'
     require_relative '../../resolvers/openbsd/dmi'
     require_relative '../../resolvers/openbsd/mountpoints'
+    require_relative '../../resolvers/openbsd/processors'
     require_relative '../../resolvers/openbsd/virtual'
 
   when 'openwrt'

--- a/lib/facter/resolvers/openbsd/processors.rb
+++ b/lib/facter/resolvers/openbsd/processors.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative '../../../facter/resolvers/bsd/processors'
+
+module Facter
+  module Resolvers
+    module Openbsd
+      class Processors < BaseResolver
+        init_resolver
+
+        class << self
+          private
+
+          def post_resolve(fact_name, _options)
+            @fact_list.fetch(fact_name) { collect_processors_info(fact_name) }
+          end
+
+          def collect_processors_info(fact_name)
+            require_relative '../../../facter/resolvers/bsd/ffi/ffi_helper'
+
+            count = online_count
+            model = processor_model
+            speed = processor_speed
+
+            @fact_list[:online_count] = count
+            @fact_list[:model] = Array.new(count, model) if online_count && model
+            @fact_list[:speed] = speed * 1000 * 1000 if speed
+
+            @fact_list[fact_name]
+          end
+
+          CTL_HW = 6
+          HW_MODEL = 2
+          HW_NCPUONLINE = 25
+          HW_CPUSPEED = 12
+
+          def processor_model
+            Facter::Bsd::FfiHelper.sysctl(:string, [CTL_HW, HW_MODEL])
+          end
+
+          def online_count
+            Facter::Bsd::FfiHelper.sysctl(:uint32_t, [CTL_HW, HW_NCPUONLINE])
+          end
+
+          def processor_speed
+            Facter::Bsd::FfiHelper.sysctl(:uint32_t, [CTL_HW, HW_CPUSPEED])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
SMT/hyperthreading is disabled by default, so not all cores are used:

```
$ sysctl hw.{smt,ncpu{,found,online}}
hw.smt=0
hw.ncpu=16
hw.ncpufound=16
hw.ncpuonline=8
$ facter processors.count
16
```

`processors.count` should thus reflect the number of cores in used,
otherwise deriving, e.g. the number of worker threads to start in
service may overcommit.

This patch fixes it:
```
$ facter processors.count
8
# sysctl hw.{smt=1,ncpu{,found,online}}
hw.smt: 0 -> 1
hw.ncpu=16
hw.ncpufound=16
hw.ncpuonline=16
$ facter processors.count
16
```

The equivalent is usually being done for other software on OpenBSD.