### PR TITLE
simplecov: allow latest version

### DIFF
--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.28', '< 1.79'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.10' # last version to support 2.5
-  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'sys-filesystem', '~> 1.4'
   spec.add_development_dependency 'webmock', '~> 3.12'
   spec.add_development_dependency 'yard', '~> 0.9'


### PR DESCRIPTION
using `skip-changelog` here because it's just a depdency for our CI setup and doesn't effect actual users