### PR TITLE
Parse mount point options with spaces correctly on OpenBSD

### DIFF
--- a/lib/facter/resolvers/openbsd/mountpoints.rb
+++ b/lib/facter/resolvers/openbsd/mountpoints.rb
@@ -27,9 +27,9 @@ module Facter
           end
 
           def add_mount_points_fact(line)
-            elem = line.split("\s")
-            options = elem.drop(5)
-            options.each { |option| option.tr!('(),', '') }
+            (elem, _, options) = line.partition("\s(")
+            elem = elem.split("\s")
+            options = options.chop!.split(",\s")
             @fact_list[:mountpoints][elem[2]] = { device: elem[0], filesystem: elem[4],
                                                   options: options }
           end


### PR DESCRIPTION
Filesystems shared via exports(5) appear like this:

```
$ mount | grep exported
/dev/sd0a on / type ffs (NFS exported, local, noatime, wxallowed)
```

Instead of splitting the line on any whitespace:
- partition it at the opening parenthese,
- split the left side like before,
- drop the closing parenthese in the right half
- and split it options on comma+whitespace:

```
 $ facter mountpoints./.options
 [
-  "NFS",
-  "exported",
+  "NFS exported",
   "local",
   "noatime",
   "wxallowed"
 ]
```
