### PR TITLE
Add tsort dependency

### DIFF
--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -53,4 +53,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'logger', '~> 1.5'
   spec.add_runtime_dependency 'ostruct', '< 0.7'
   spec.add_runtime_dependency 'thor', ['>= 1.0.1', '< 2']
+  spec.add_runtime_dependency 'tsort', '< 0.3'
 end


### PR DESCRIPTION
Without this, we get the following warning:

```
/home/runner/work/openfact/openfact/lib/facter/custom_facts/core/directed_graph.rb:4: warning: tsort was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.1.0
You can add tsort to your Gemfile or gemspec to silence this warning.
```