### PR TITLE
networking.interfaces: Provide ifconfig(8) flags, rdomain, description and groups

### DIFF
--- a/lib/facter/resolvers/networking.rb
+++ b/lib/facter/resolvers/networking.rb
@@ -49,8 +49,12 @@ module Facter
           interfaces_data.each do |interface_name, raw_data|
             parsed_interface_data = {}
 
+            extract_flags(raw_data, parsed_interface_data)
+            extract_rdomain(raw_data, parsed_interface_data)
             extract_mtu(raw_data, parsed_interface_data)
             extract_mac(raw_data, parsed_interface_data)
+            extract_description(raw_data, parsed_interface_data)
+            extract_groups(raw_data, parsed_interface_data)
             extract_dhcp(interface_name, raw_data, parsed_interface_data)
             extract_ip_data(raw_data, parsed_interface_data)
 
@@ -59,9 +63,29 @@ module Facter
           @fact_list[:interfaces] = parsed_interfaces_data unless parsed_interfaces_data.empty?
         end
 
+        def extract_flags(raw_data, parsed_interface_data)
+          flags = raw_data.match(/flags=\d+<(.+)>/)&.captures&.first
+          parsed_interface_data[:flags] = flags.split(',') unless flags.nil?
+        end
+
+        def extract_rdomain(raw_data, parsed_interface_data)
+          rdomain = raw_data.match(/rdomain\s+(\d+)/)&.captures&.first&.to_i
+          parsed_interface_data[:rdomain] = rdomain unless rdomain.nil?
+        end
+
         def extract_mtu(raw_data, parsed_interface_data)
           mtu = raw_data.match(/mtu\s+(\d+)/)&.captures&.first&.to_i
           parsed_interface_data[:mtu] = mtu unless mtu.nil?
+        end
+
+        def extract_description(raw_data, parsed_interface_data)
+          description = raw_data.match(/description:\s+(.+)/)&.captures&.first
+          parsed_interface_data[:description] = description unless description.nil?
+        end
+
+        def extract_groups(raw_data, parsed_interface_data)
+          groups = raw_data.match(/groups:\s+(.+)/)&.captures&.first
+          parsed_interface_data[:groups] = groups.split("\s") unless groups.nil?
         end
 
         def extract_mac(raw_data, parsed_interface_data)

--- a/spec/facter/resolvers/networking_spec.rb
+++ b/spec/facter/resolvers/networking_spec.rb
@@ -18,13 +18,15 @@ describe Facter::Resolvers::Networking do
         .to receive(:execute).with('ipconfig getoption llw0 server_identifier', logger: an_instance_of(Facter::Log)).and_return('')
       allow(Facter::Core::Execution)
         .to receive(:execute).with('ipconfig getoption awdl0 server_identifier', logger: an_instance_of(Facter::Log)).and_return(dhcp)
+      allow(Facter::Core::Execution)
+        .to receive(:execute).with('ipconfig getoption pair2 server_identifier', logger: an_instance_of(Facter::Log)).and_return('')
     end
 
     after do
       networking.invalidate_cache
     end
 
-    let(:interfaces) { load_fixture('ifconfig_mac').read }
+    let(:interfaces) { load_fixture('ifconfig').read }
     let(:dhcp) { '192.168.143.1' }
     let(:primary) { 'en0' }
 
@@ -37,12 +39,12 @@ describe Facter::Resolvers::Networking do
     end
 
     it 'detects all interfaces' do
-      expected = %w[lo0 gif0 stf0 en0 en0.1 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2 utun3 ib0 ib1]
+      expected = %w[lo0 gif0 stf0 en0 en0.1 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2 utun3 ib0 ib1 pair2]
       expect(networking.resolve(:interfaces).keys).to match_array(expected)
     end
 
     it 'checks that interface lo0 has the expected keys' do
-      expected = %i[mtu bindings6 bindings ip ip6 netmask netmask6 network network6 scope6]
+      expected = %i[flags mtu bindings6 bindings ip ip6 netmask netmask6 network network6 scope6]
       expect(networking.resolve(:interfaces)['lo0'].keys).to match_array(expected)
     end
 
@@ -68,17 +70,17 @@ describe Facter::Resolvers::Networking do
     end
 
     it 'detects interface en1' do
-      expected = { mtu: 1500, mac: '82:17:0e:93:9d:00' }
+      expected = { flags: %w[UP BROADCAST SMART RUNNING PROMISC SIMPLEX MULTICAST], mtu: 1500, mac: '82:17:0e:93:9d:00' }
       expect(networking.resolve(:interfaces)['en1']).to eq(expected)
     end
 
     it 'detects interface gif0' do
-      expected = { mtu: 1280 }
+      expected = { flags: %w[POINTOPOINT MULTICAST], mtu: 1280 }
       expect(networking.resolve(:interfaces)['gif0']).to eq(expected)
     end
 
     it 'checks that interface en0 has the expected keys' do
-      expected = %i[mtu mac bindings ip netmask network dhcp]
+      expected = %i[flags mtu mac bindings ip netmask network dhcp]
       expect(networking.resolve(:interfaces)['en0'].keys).to match_array(expected)
     end
 
@@ -113,7 +115,7 @@ describe Facter::Resolvers::Networking do
     end
 
     it 'checks that interface awdl0 has the expected keys' do
-      expected = %i[mtu mac bindings6 ip6 netmask6 network6 scope6 dhcp]
+      expected = %i[flags mtu mac bindings6 ip6 netmask6 network6 scope6 dhcp]
       expect(networking.resolve(:interfaces)['awdl0'].keys).to match_array(expected)
     end
 
@@ -133,6 +135,11 @@ describe Facter::Resolvers::Networking do
           network: '2001:db8:cafe::132:213', scope6: 'global' }
       ] }
       expect(networking.resolve(:interfaces)['utun3']).to include(expected)
+    end
+
+    it 'checks that interface pair2 has description, rdomain and groups' do
+      expected = { rdomain: 46, description: 'gelatod CLAT 464XLAT', groups: %w[pair] }
+      expect(networking.resolve(:interfaces)['pair2']).to include(expected)
     end
 
     it 'checks interface ib0 has the expected mac' do

--- a/spec/fixtures/ifconfig
+++ b/spec/fixtures/ifconfig
@@ -88,3 +88,12 @@ ib1: flags=4099<UP,BROADCAST,MULTICAST>  mtu 4092
         TX packets 0  bytes 0 (0.0 B)
         TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
 
+pair2: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> rdomain 46 mtu 1500
+	lladdr fe:e1:ba:d1:c3:a7
+	description: gelatod CLAT 464XLAT
+	index 6 priority 0 llprio 3
+	patch: pair1
+	groups: pair
+	media: Ethernet autoselect
+	status: active
+	inet 192.0.0.1 netmask 0xfffffff8 broadcast 192.0.0.7


### PR DESCRIPTION
OpenBSD, FreeBSD and macOS all show interface flags the same way.
OpenBSD and FreeBSD support descriptions and groups.
OpenBSD has https://man.openbsd.org/rdomain.4 as well.

If these properties are not set or ifconfig does not print them,
they will simply not appear.

This allows OpenVox to act upon such details without shelling out to
custom scripts;  without either of this there is currently no way to
ensure (partial) interface state.

Example from OpenBSD:
```
pair2: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> rdomain 46 mtu 1500
	lladdr fe:e1:ba:d1:c3:a7
	description: gelatod CLAT 464XLAT
	index 6 priority 0 llprio 3
	patch: pair1
	groups: pair
	media: Ethernet autoselect
	status: active
	inet 192.0.0.1 netmask 0xfffffff8 broadcast 192.0.0.7
```

Result:
```
 {
   bindings => [
     {
       address => "192.0.0.1",
       netmask => "255.255.255.248",
       network => "192.0.0.0"
     }
   ],
+  description => "gelatod CLAT 464XLAT",
+  flags => [
+    "UP",
+    "BROADCAST",
+    "RUNNING",
+    "SIMPLEX",
+    "MULTICAST"
+  ],
+  groups => [
+    "pair"
+  ],
   ip => "192.0.0.1",
   mac => "fe:e1:ba:d1:c3:a7",
   mtu => 1500,
   netmask => "255.255.255.248",
   network => "192.0.0.0",
+  rdomain => 46
 }
```
