### PR TITLE
Gemfile: Remove Gemfile.local hack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,3 @@ group(:release, optional: true) do
 end
 
 gem 'packaging', require: false
-
-local_gemfile = File.expand_path('Gemfile.local', __dir__)
-eval_gemfile(local_gemfile) if File.exist?(local_gemfile)


### PR DESCRIPTION
We don't use Gemfiles that aren't tracked by git and it breaks dependabot.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
