### PR TITLE
interfaces: parse flags radix correctly

### DIFF
--- a/lib/facter/resolvers/networking.rb
+++ b/lib/facter/resolvers/networking.rb
@@ -64,7 +64,7 @@ module Facter
         end
 
         def extract_flags(raw_data, parsed_interface_data)
-          flags = raw_data.match(/flags=\d+<(.+)>/)&.captures&.first
+          flags = raw_data.match(/flags=\h+<(.+)>/)&.captures&.first
           parsed_interface_data[:flags] = flags.split(',') unless flags.nil?
         end
 

--- a/spec/facter/resolvers/networking_spec.rb
+++ b/spec/facter/resolvers/networking_spec.rb
@@ -20,6 +20,8 @@ describe Facter::Resolvers::Networking do
         .to receive(:execute).with('ipconfig getoption awdl0 server_identifier', logger: an_instance_of(Facter::Log)).and_return(dhcp)
       allow(Facter::Core::Execution)
         .to receive(:execute).with('ipconfig getoption pair2 server_identifier', logger: an_instance_of(Facter::Log)).and_return('')
+      allow(Facter::Core::Execution)
+        .to receive(:execute).with('ipconfig getoption vlan42 server_identifier', logger: an_instance_of(Facter::Log)).and_return('')
     end
 
     after do
@@ -39,7 +41,7 @@ describe Facter::Resolvers::Networking do
     end
 
     it 'detects all interfaces' do
-      expected = %w[lo0 gif0 stf0 en0 en0.1 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2 utun3 ib0 ib1 pair2]
+      expected = %w[lo0 gif0 stf0 en0 en0.1 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2 utun3 ib0 ib1 pair2 vlan42]
       expect(networking.resolve(:interfaces).keys).to match_array(expected)
     end
 
@@ -140,6 +142,10 @@ describe Facter::Resolvers::Networking do
     it 'checks that interface pair2 has description, rdomain and groups' do
       expected = { rdomain: 46, description: 'gelatod CLAT 464XLAT', groups: %w[pair] }
       expect(networking.resolve(:interfaces)['pair2']).to include(expected)
+    end
+
+    it 'checks that interface vlan42 has hexadecimal flags value' do
+      expect(networking.resolve(:interfaces)['vlan42'][:flags]).to be_an_instance_of(Array)
     end
 
     it 'checks interface ib0 has the expected mac' do

--- a/spec/fixtures/ifconfig
+++ b/spec/fixtures/ifconfig
@@ -97,3 +97,13 @@ pair2: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> rdomain 46 mtu 1500
 	media: Ethernet autoselect
 	status: active
 	inet 192.0.0.1 netmask 0xfffffff8 broadcast 192.0.0.7
+vlan42: flags=a08843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,AUTOCONF6,AUTOCONF4> mtu 1500
+	lladdr 00:11:22:33:44:55
+	index 42 priority 0 llprio 3
+	encap: vnetid 42 parent cnmac0 txprio packet rxprio outer
+	groups: vlan egress
+	media: Ethernet autoselect (1000baseT full-duplex,master)
+	status: active
+	inet6 fe80::211:22ff:fe33:4455%vlan3 prefixlen 64 scopeid 0xa
+	inet6 2001:db8::1 prefixlen 64 autoconf pltime 123 vltime 123
+	inet 192.0.2.1 netmask 0xffffff00 broadcast 192.0.2.255


### PR DESCRIPTION
ifconfig(8) flags aka. printf(9) `%b` may start with hexadecimal characters:
https://github.com/openbsd/src/blob/782aef866e55128b1259c9ea5c8fb1134165876d/sbin/ifconfig/ifconfig.c#L6530-L6542

This yields facter values when, e.g. both SLAAC and DHCP are enabled:
```
 $ ifconfig vlan42 | grep flags
 vlan42: a08843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST,AUTOCONF6,AUTOCONF4 mtu 1500
 $ facter networking.interfaces.vlan42.flags | jq -c
-
+["UP","BROADCAST","RUNNING","SIMPLEX","MULTICAST","AUTOCONF6","AUTOCONF4"]
```
