### PR TITLE
Remove deprecated ldapname fact option and accessor

### DIFF
--- a/lib/facter/custom_facts/util/collection.rb
+++ b/lib/facter/custom_facts/util/collection.rb
@@ -162,8 +162,6 @@ module LegacyFacter
         if fact.nil?
           fact = Facter::Util::Fact.new(name, options)
           @facts[name] = fact
-        else
-          fact.extract_ldapname_option!(options)
         end
 
         fact

--- a/lib/facter/custom_facts/util/fact.rb
+++ b/lib/facter/custom_facts/util/fact.rb
@@ -17,10 +17,6 @@ module Facter
       # @return [String]
       attr_reader :name
 
-      # @return [String]
-      # @deprecated
-      attr_accessor :ldapname
-
       # Fact options e.g. fact_type
       attr_accessor :options
 
@@ -31,16 +27,12 @@ module Facter
       # for the public API for creating facts.
       # @param name [String] the fact name
       # @param options [Hash] optional parameters
-      # @option options [String] :ldapname set the ldapname property on the fact
       #
       # @api private
       def initialize(name, options = {})
         @name = LegacyFacter::Util::Normalization.normalize(name.to_s.downcase).intern
 
         @options = options.dup
-        extract_ldapname_option!(options)
-
-        @ldapname ||= @name.to_s
 
         @resolves = []
         @searching = false
@@ -140,15 +132,6 @@ module Facter
         end
 
         @value
-      end
-
-      # @api private
-      # @deprecated
-      def extract_ldapname_option!(options)
-        return unless options[:ldapname]
-
-        log.warnonce('ldapname is deprecated and will be removed in a future version')
-        self.ldapname = options.delete(:ldapname)
       end
 
       private

--- a/spec/custom_facts/util/collection_spec.rb
+++ b/spec/custom_facts/util/collection_spec.rb
@@ -93,12 +93,6 @@ describe LegacyFacter::Util::Collection do
       expect(collection.define_fact(:newfact)).to equal fact
     end
 
-    it 'passes options to newly generated facts' do
-      allow(logger).to receive(:warnonce)
-      fact = collection.define_fact(:newfact, ldapname: 'NewFact')
-      expect(fact.ldapname).to eq 'NewFact'
-    end
-
     it 'logs an error if the fact name contains the utf-8 null byte' do
       name = "Uncool\0Name"
       normalization_error = LegacyFacter::Util::Normalization::NormalizationError

--- a/spec/custom_facts/util/fact_spec.rb
+++ b/spec/custom_facts/util/fact_spec.rb
@@ -50,11 +50,6 @@ describe Facter::Util::Fact do
     expect(Facter::Util::Fact.new('YayNess').name).to eq :yayness
   end
 
-  it 'issues a deprecation warning for use of ldapname' do
-    expect(logger).to receive(:warnonce).with('ldapname is deprecated and will be removed in a future version')
-    Facter::Util::Fact.new('YayNess', ldapname: 'fooness')
-  end
-
   describe 'when adding resolution mechanisms using #add' do
     it 'delegates to #define_resolution with an anonymous resolution' do
       expect(fact).to receive(:define_resolution).with(nil, {})


### PR DESCRIPTION
### Short description
The ldapname feature was deprecated with a runtime warning. This commit completes the removal per OpenVox Platform Deprecation Schedule (issue #87):

- Remove `ldapname` attr_accessor from Facter::Util::Fact
- Remove `extract_ldapname_option!` method and its call in initialize
- Remove forwarding call to extract_ldapname_option! in Collection#create_or_return_fact
- Remove associated tests

Closes #87

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
