### PR TITLE
Remove deprecated Facter::Core::Execution.exec

### DIFF
--- a/lib/facter/custom_facts/core/execution.rb
+++ b/lib/facter/custom_facts/core/execution.rb
@@ -87,19 +87,6 @@ module Facter
         @@impl.with_env(values, &block)
       end
 
-      # Try to execute a command and return the output.
-      #
-      # @param command [String] Command to run
-      #
-      # @return [String/nil] Output of the program, or nil if the command does
-      #   not exist or could not be executed.
-      #
-      # @deprecated Use #{execute} instead
-      # @api public
-      def exec(command)
-        @@impl.execute(command, on_fail: nil)
-      end
-
       # Execute a command and return the output of that program.
       #
       # @param command [String] Command to run

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -36,11 +36,6 @@ describe Facter::Core::Execution do
     execution.expand_command('waffles')
   end
 
-  it 'delegates #exec to #execute' do
-    expect(impl).to receive(:execute).with('waffles', { on_fail: nil })
-    execution.exec('waffles')
-  end
-
   it 'delegates #execute to the implementation' do
     expect(impl).to receive(:execute).with('waffles', {})
     execution.execute('waffles')


### PR DESCRIPTION
### Short description
`exec` was deprecated in favor of `execute`. This commit completes the removal per the OpenVox Platform Deprecation Schedule (issue #88).

Closes #88

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
