### PR TITLE
Remove deprecated exec/which exposure from Facter::Util::Resolution

### DIFF
--- a/acceptance/tests/custom_facts/execution_execute_sets_status_env_variable.rb
+++ b/acceptance/tests/custom_facts/execution_execute_sets_status_env_variable.rb
@@ -13,7 +13,7 @@ test_name "(FACT-2934) Facter::Core::Execution sets $?" do
     content = <<-EOM
     Facter.add(:foo) do
       setcode do
-         Facter::Util::Resolution.exec("#{command}")
+         Facter::Core::Execution.execute("#{command}", on_fail: nil)
          "#{command} exited with code: %{status}" % {status: $?.exitstatus}
       end
     end

--- a/lib/facter/custom_facts/core/execution.rb
+++ b/lib/facter/custom_facts/core/execution.rb
@@ -87,19 +87,6 @@ module Facter
         @@impl.with_env(values, &block)
       end
 
-      # Try to execute a command and return the output.
-      #
-      # @param command [String] Command to run
-      #
-      # @return [String/nil] Output of the program, or nil if the command does
-      #   not exist or could not be executed.
-      #
-      # @deprecated Use #{execute} instead
-      # @api public
-      def exec(command)
-        @@impl.execute(command, on_fail: nil)
-      end
-
       # Execute a command and return the output of that program.
       #
       # @param command [String] Command to run

--- a/lib/facter/custom_facts/util/resolution.rb
+++ b/lib/facter/custom_facts/util/resolution.rb
@@ -23,15 +23,6 @@ module Facter
       extend Facter::Core::Execution
 
       class << self
-        # Expose command execution methods that were extracted into
-        # Facter::Core::Execution from Facter::Util::Resolution in Facter 2.0.0 for
-        # compatibility.
-        #
-        # @deprecated
-        #
-        # @api public
-        public :which, :exec
-
         # @api private
         public :with_env
       end

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -36,11 +36,6 @@ describe Facter::Core::Execution do
     execution.expand_command('waffles')
   end
 
-  it 'delegates #exec to #execute' do
-    expect(impl).to receive(:execute).with('waffles', { on_fail: nil })
-    execution.exec('waffles')
-  end
-
   it 'delegates #execute to the implementation' do
     expect(impl).to receive(:execute).with('waffles', {})
     execution.execute('waffles')


### PR DESCRIPTION
### Short description
Remove deprecated Facter::Core::Execution.exec and Resolution compatibility

Remove `Facter::Core::Execution.exec`, which was deprecated in favor of `Facter::Core::Execution.execute` (#88).

Remove the deprecated class-level `exec`/`which` compatibility exposure from `Facter::Util::Resolution` that bridged to `Facter::Core::Execution` since Facter 2.0.0 (#89). These two removals are coupled — `exec` on `Resolution` delegated through `Execution.exec`, so they must ship together.

Update the acceptance test that called `Facter::Util::Resolution.exec` to use `Facter::Core::Execution.execute(cmd, on_fail: nil)` directly.

Closes #88 #89

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
