### PR TITLE
Deprecate time_limit and limit timeout aliases in Facter::Core::Execution.execute

### DIFF
--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -8,6 +8,7 @@ module Facter
       class Base
         STDERR_MESSAGE = 'Command %s completed with the following stderr message: %s'
         VALID_OPTIONS = %i[on_fail expand logger timeout].freeze
+        DEPRECATED_TIMEOUT_OPTIONS = %i[time_limit limit].freeze
         DEFAULT_EXECUTION_TIMEOUT = 300
         def initialize
           @log = Log.new(self)
@@ -117,7 +118,11 @@ module Facter
           timeout = (options[:timeout] || options[:time_limit] || options[:limit]).to_i
           timeout = timeout.positive? ? timeout : nil
 
-          extra_keys = options.keys - VALID_OPTIONS
+          (options.keys & DEPRECATED_TIMEOUT_OPTIONS).each do |key|
+            @log.warnonce("#{key} is deprecated and will be removed in a future version, use timeout instead")
+          end
+
+          extra_keys = options.keys - VALID_OPTIONS - DEPRECATED_TIMEOUT_OPTIONS
           unless extra_keys.empty?
             @log.warn("Unexpected key passed to Facter::Core::Execution.execute option: #{extra_keys.join(',')}" \
                       " - valid keys: #{VALID_OPTIONS.join(',')}")

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -68,23 +68,32 @@ describe Facter::Core::Execution do
 
     context 'when passing deprecated arguments' do
       %i[time_limit limit].each do |option|
-        it 'executes the found command with a timeout' do
+        it "executes the found command with a timeout when #{option} is used" do
+          allow(logger).to receive(:warnonce)
           execution.execute('waffles', option => 90)
           expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
         end
+
+        it "emits a deprecation warning when #{option} is used" do
+          expect(logger).to receive(:warnonce)
+            .with("#{option} is deprecated and will be removed in a future version, use timeout instead")
+          execution.execute('waffles', option => 90)
+        end
       end
 
-      it 'emits a warning to the default logger' do
+      it 'does not include deprecated timeout keys in the unexpected key warning' do
+        allow(logger).to receive(:warnonce)
         expect(logger).to receive(:warn)
-          .with('Unexpected key passed to Facter::Core::Execution.execute option: time_limit,bad_opt' \
+          .with('Unexpected key passed to Facter::Core::Execution.execute option: bad_opt' \
             ' - valid keys: on_fail,expand,logger,timeout')
 
         execution.execute('waffles', time_limit: 90, bad_opt: true)
       end
 
-      it 'ignores the passed in logger when logging the warning' do
+      it 'ignores the passed in logger when logging warnings' do
+        allow(logger).to receive(:warnonce)
         expect(logger).to receive(:warn)
-          .with('Unexpected key passed to Facter::Core::Execution.execute option: time_limit,bad_opt' \
+          .with('Unexpected key passed to Facter::Core::Execution.execute option: bad_opt' \
             ' - valid keys: on_fail,expand,logger,timeout')
 
         execution.execute('waffles', time_limit: 90, bad_opt: true, logger: Facter::Log.new('ignored'))


### PR DESCRIPTION
### Short description
These option keys are compatibility aliases for `:timeout`. Emit a specific `warnonce` deprecation message for each when used, rather than surfacing them through the generic unexpected-key warning.

Closes #90

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
