### PR TITLE
Deprecate Resolvable#limit compatibility bridge for timeout

### DIFF
--- a/lib/facter/custom_facts/core/resolvable.rb
+++ b/lib/facter/custom_facts/core/resolvable.rb
@@ -20,11 +20,9 @@ module LegacyFacter
       # Return the timeout period for resolving a value.
       # (see #timeout)
       # @return [Numeric]
-      # @comment requiring 'timeout' stdlib class causes Object#timeout to be
-      #   defined which delegates to Timeout.timeout. This method may potentially
-      #   overwrite the #timeout attr_reader on this class, so we define #limit to
-      #   avoid conflicts.
+      # @deprecated Use timeout instead.
       def limit
+        Facter::Log.new(self).warnonce('limit is deprecated and will be removed in a future version, use timeout instead')
         @timeout || 0
       end
 
@@ -74,14 +72,14 @@ module LegacyFacter
         result = nil
 
         with_timing do
-          Timeout.timeout(limit) do
+          Timeout.timeout(@timeout || 0) do
             result = resolve_value
           end
         end
 
         LegacyFacter::Util::Normalization.normalize(result)
       rescue Timeout::Error => e
-        Facter.log_exception(e, "Timed out after #{limit} seconds while resolving #{qualified_name}")
+        Facter.log_exception(e, "Timed out after #{@timeout || 0} seconds while resolving #{qualified_name}")
 
         nil
       rescue LegacyFacter::Util::Normalization::NormalizationError => e

--- a/spec/custom_facts/core/resolvable_spec.rb
+++ b/spec/custom_facts/core/resolvable_spec.rb
@@ -25,6 +25,10 @@ describe LegacyFacter::Core::Resolvable do
     allow(Facter::Log).to receive(:new).and_return(log)
   end
 
+  after do
+    Facter.remove_instance_variable(:@logger) if Facter.instance_variable_defined?(:@logger)
+  end
+
   it 'has a default timeout of 0 seconds' do
     expect(resolvable.limit).to eq 0
   end

--- a/spec/custom_facts/core/resolvable_spec.rb
+++ b/spec/custom_facts/core/resolvable_spec.rb
@@ -19,8 +19,19 @@ end
 describe LegacyFacter::Core::Resolvable do
   subject(:resolvable) { FacterSpec::ResolvableClass.new('resolvable') }
 
+  let(:log) { instance_spy(Facter::Log) }
+
+  before do
+    allow(Facter::Log).to receive(:new).and_return(log)
+  end
+
   it 'has a default timeout of 0 seconds' do
     expect(resolvable.limit).to eq 0
+  end
+
+  it 'emits a deprecation warning when limit is called' do
+    expect(log).to receive(:warnonce).with('limit is deprecated and will be removed in a future version, use timeout instead')
+    resolvable.limit
   end
 
   it 'can specify a custom timeout' do
@@ -61,9 +72,8 @@ describe LegacyFacter::Core::Resolvable do
   end
 
   describe 'timing out' do
-    it 'uses #limit instead of #timeout to determine the timeout period' do
-      expect(resolvable).not_to receive(:timeout)
-      allow(resolvable).to receive(:limit).and_return(25)
+    it 'uses @timeout directly to determine the timeout period' do
+      resolvable.timeout = 25
       allow(Timeout).to receive(:timeout).with(25)
 
       resolvable.value


### PR DESCRIPTION
### Short description
`limit` was added to avoid a naming conflict with `Timeout.timeout` overwriting the `attr_reader`. Move internal callers in value to use `@timeout || 0` directly so the deprecation warning only fires for external callers.

Closes #91

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
