### PR TITLE
Fix unclosed .Bl list in FILES section of man.erb

### DIFF
--- a/lib/facter/templates/man.erb
+++ b/lib/facter/templates/man.erb
@@ -32,6 +32,7 @@ Many of the command line options can also be set via the HOCON config file. This
 .Bl -tag
 .It /etc/puppetlabs/facter/facter.conf
 A HOCON config file that can be used to specify directories for custom and external facts, set various command line options, and specify facts to block. See example below for details, or visit the [GitHub README](https://github.com/puppetlabs/puppetlabs-hocon#overview).
+.El
 .Sh EXAMPLES
 Display all facts:
 .Bd -literal -offset indent


### PR DESCRIPTION
## Summary

- The `.Bl -tag` list in the `FILES` section of `man.erb` was missing its closing `.El` macro before `.Sh EXAMPLES`, producing malformed mdoc
- This causes `pandoc-ruby`'s strict mdoc reader (used by openvox-docs to convert `facter man` output to Markdown) to abort doc generation
- Fix is a single `.El` line insertion

## Test plan

- [x] Run `facter man` and verify output is valid mdoc (parseable by `mandoc -T lint`)
- [ ] Verify openvox-docs pipeline succeeds after this fix: `bundle exec rake references:facter VERSION=<tag>`

## Linting

```
bundle exec rubocop lib/facter/templates/man.erb
```

> `man.erb` is not a Ruby file — rubocop does not apply.

## Notes

This fix is a prerequisite for the corresponding openvox-docs fix (miharp/openvox-docs#fix/facter-cli-troff-conversion), which uses `pandoc-ruby` to convert the mdoc output to Markdown for the documentation site.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)