### PR TITLE
deprecation: add runtime warnings to deprecated exec/which methods

### DIFF
--- a/lib/facter/custom_facts/core/execution.rb
+++ b/lib/facter/custom_facts/core/execution.rb
@@ -94,9 +94,11 @@ module Facter
       # @return [String/nil] Output of the program, or nil if the command does
       #   not exist or could not be executed.
       #
-      # @deprecated Use #{execute} instead
+      # @deprecated Use {execute} instead
       # @api public
       def exec(command)
+        Facter.warnonce('Facter::Core::Execution.exec is deprecated and will be removed in a future major version. ' \
+                        'Use Facter::Core::Execution.execute instead.')
         @@impl.execute(command, on_fail: nil)
       end
 

--- a/lib/facter/custom_facts/util/resolution.rb
+++ b/lib/facter/custom_facts/util/resolution.rb
@@ -23,14 +23,21 @@ module Facter
       extend Facter::Core::Execution
 
       class << self
-        # Expose command execution methods that were extracted into
-        # Facter::Core::Execution from Facter::Util::Resolution in Facter 2.0.0 for
-        # compatibility.
-        #
-        # @deprecated
-        #
+        # @deprecated Use Facter::Core::Execution.which instead
         # @api public
-        public :which, :exec
+        def which(bin)
+          Facter.warnonce('Facter::Util::Resolution.which is deprecated and will be removed in a future major version. ' \
+                          'Use Facter::Core::Execution.which instead.')
+          Facter::Core::Execution.which(bin)
+        end
+
+        # @deprecated Use Facter::Core::Execution.execute instead
+        # @api public
+        def exec(command)
+          Facter.warnonce('Facter::Util::Resolution.exec is deprecated and will be removed in a future major version. ' \
+                          'Use Facter::Core::Execution.execute instead.')
+          Facter::Core::Execution.execute(command, on_fail: nil)
+        end
 
         # @api private
         public :with_env

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -37,6 +37,7 @@ describe Facter::Core::Execution do
   end
 
   it 'delegates #exec to #execute' do
+    expect(Facter).to receive(:warnonce).with(a_string_including('Facter::Core::Execution.exec is deprecated'))
     expect(impl).to receive(:execute).with('waffles', { on_fail: nil })
     execution.exec('waffles')
   end

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -118,6 +118,34 @@ describe Facter::Util::Resolution do
     end
   end
 
+  describe '.which (deprecated)' do
+    it 'emits a deprecation warning' do
+      allow(Facter::Core::Execution).to receive(:which).and_return('/usr/bin/foo')
+      expect(Facter).to receive(:warnonce).with(a_string_including('Facter::Util::Resolution.which is deprecated'))
+      Facter::Util::Resolution.which('foo')
+    end
+
+    it 'delegates to Facter::Core::Execution.which' do
+      allow(Facter).to receive(:warnonce)
+      expect(Facter::Core::Execution).to receive(:which).with('foo').and_return('/usr/bin/foo')
+      expect(Facter::Util::Resolution.which('foo')).to eq('/usr/bin/foo')
+    end
+  end
+
+  describe '.exec (deprecated)' do
+    it 'emits a deprecation warning' do
+      allow(Facter::Core::Execution).to receive(:execute).and_return('output')
+      expect(Facter).to receive(:warnonce).with(a_string_including('Facter::Util::Resolution.exec is deprecated'))
+      Facter::Util::Resolution.exec('foo')
+    end
+
+    it 'delegates to Facter::Core::Execution.execute with on_fail: nil' do
+      allow(Facter).to receive(:warnonce)
+      expect(Facter::Core::Execution).to receive(:execute).with('foo', on_fail: nil).and_return('output')
+      expect(Facter::Util::Resolution.exec('foo')).to eq('output')
+    end
+  end
+
   describe 'evaluating' do
     it 'evaluates the block in the context of the given resolution' do
       expect(resolution).to receive(:setcode).with('code')


### PR DESCRIPTION
### Short description
Add explicit runtime deprecation warnings (via Facter.warnonce) to methods that are slated for removal in a future major version:

- Facter::Core::Execution.exec: warn callers to use .execute instead
- Facter::Util::Resolution.exec: replaced bare public :exec with an explicit method that warns and delegates to Facter::Core::Execution
- Facter::Util::Resolution.which: same treatment as .exec above

Specs updated to assert the deprecation warning is emitted; new specs added for the Resolution class-level deprecated methods.

References #88, #89

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
