### PR TITLE
WIP: integrating SLES wicked dhcp lease into openfact

### DIFF
--- a/lib/facter/util/linux/dhcp.rb
+++ b/lib/facter/util/linux/dhcp.rb
@@ -21,10 +21,25 @@ module Facter
             dhcp ||= search_dhclient_leases(interface_name)
             dhcp ||= search_internal_leases(interface_name)
             dhcp ||= search_with_dhcpcd_command(interface_name)
+            dhcp ||= search_wicked_leases(interface_name)
             dhcp
           end
 
           private
+
+          def search_wicked_leases(interface_name)
+            path_candidate = "/var/lib/wicked/lease-#{interface_name}-dhcp-ipv4.xml"
+
+            return unless File.exist? path_candidate
+
+            @log.debug("Attempt to get DHCP for interface #{interface_name}, from #{path_candidate}")
+
+            require 'rexml/document'
+
+            xmlstring = File.open(path_candidate).read.gsub('ipv4:dhcp', 'ipv4_dhcp')
+            rex = REXML::Document.new xmlstring
+            rex.root.elements['/lease/ipv4_dhcp/server-id/'].text
+          end
 
           def search_systemd_netif_leases(index, interface_name)
             return if index.nil?


### PR DESCRIPTION
### Short description

SLES uses wicked, which is a systemd overlay. This fact parses wicked for IPv4 DHCP leases.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
