### PR TITLE
search_path: Add common elements from $PATH

### DIFF
--- a/lib/facter/custom_facts/core/execution/posix.rb
+++ b/lib/facter/custom_facts/core/execution/posix.rb
@@ -4,7 +4,7 @@ module Facter
   module Core
     module Execution
       class Posix < Facter::Core::Execution::Base
-        DEFAULT_SEARCH_PATHS = ['/sbin', '/usr/sbin'].freeze
+        DEFAULT_SEARCH_PATHS = ['/sbin', '/usr/sbin', '/opt/puppetlabs/bin'].freeze
 
         def search_paths
           # Make sure custom_facts is usable even for non-root users. Most commands

--- a/spec/custom_facts/core/execution/posix_spec.rb
+++ b/spec/custom_facts/core/execution/posix_spec.rb
@@ -6,7 +6,7 @@ describe Facter::Core::Execution::Posix, unless: LegacyFacter::Util::Config.wind
   describe '#search_paths' do
     it 'uses the PATH environment variable plus /sbin and /usr/sbin on unix' do
       allow(ENV).to receive(:[]).with('PATH').and_return '/bin:/usr/bin'
-      expect(posix_executor.search_paths).to eq %w[/bin /usr/bin /sbin /usr/sbin]
+      expect(posix_executor.search_paths).to eq %w[/bin /usr/bin /sbin /usr/sbin /opt/puppetlabs/bin]
     end
   end
 


### PR DESCRIPTION
Previously, we only had to paths where we looked for binaries + `$PATH`. Those two paths were `/sbin` and `/usr/sbin`. This covers most binaries, but relying on $PATH is... unreliable. e.g. many people assume that `/opt/puppetlabs/bin` is available in `search_paths`. But this isn't guaranteed. It's added to `$PATH` by `/etc/profile.d/puppet-agent.sh`. So it's only available in interactive shells.

This causes the following bug:

https://github.com/voxpupuli/puppet-openvoxdb/blob/56261b7b5dda7211d610cf5b28b8356a7ab41b52/lib/facter/openvoxdb_version.rb#L5

When running `puppet agent -t`, this fact works and `puppetdb` is found at `/opt/puppetlabs/bin/puppetdb`. When running the puppet.service unit, `/etc/profile.d/puppet-agent.sh` isn't sourced so the fact is nil. And IMO this is a bug in OpenFact.

The whole list is still prefixed by `$PATH`.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
