### PR TITLE
Fix missing .El tag in manpage

### DIFF
--- a/man/man1/facter.1
+++ b/man/man1/facter.1
@@ -77,6 +77,7 @@ Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.
 .Bl -tag
 .It /etc/puppetlabs/facter/facter.conf
 A HOCON config file that can be used to specify directories for custom and external facts, set various command line options, and specify facts to block. See example below for details, or visit the [GitHub README](https://github.com/puppetlabs/puppetlabs-hocon#overview).
+.El
 .Sh EXAMPLES
 Display all facts:
 .Bd -literal -offset indent


### PR DESCRIPTION
Detected via Lintian, see https://lintian.debian.org/tags/groff-message.html