### PR TITLE
Add Ruby 4 support+tests on windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,7 @@ jobs:
         ruby:
           - '2.7'
           - '3.2'
+          - '4.0'
     runs-on: windows-2025
     steps:
       - name: Checkout current PR
@@ -161,8 +162,9 @@ jobs:
           - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
           - {os: ubuntu-latest, ruby: 'jruby-9.4.15.0'} # OpenVox 8 target https://github.com/OpenVoxProject/jruby-deps/pull/21
           - {os: ubuntu-latest, ruby: 'jruby-10.0.5.0'}
-          - {os: windows-2022, ruby: '2.7'}
-          - {os: windows-2022, ruby: '3.2'} # with openssl 3
+          - {os: windows-2025, ruby: '2.7'}
+          - {os: windows-2025, ruby: '3.2'}
+          - {os: windows-2025, ruby: '4.0'}
     runs-on: ${{ matrix.cfg.os }}
     env:
       BUNDLE_WITH: 'integration'

--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -54,4 +54,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ostruct', '< 0.7'
   spec.add_runtime_dependency 'thor', ['>= 1.0.1', '< 2']
   spec.add_runtime_dependency 'tsort', '< 0.3'
+  # we have the same for openvox
+  if Gem.win_platform?
+    spec.add_runtime_dependency 'fiddle', '~> 1.1'
+    spec.add_runtime_dependency 'win32ole', '~> 1.8'
+  end
 end


### PR DESCRIPTION
We need to explicitly add the win32ole dependency on Ruby4 and newer. We did the same for openvox.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
