### PR TITLE
CI: fix job ordering

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,8 @@ jobs:
       - run: bundle exec rake spec_random
 
   windows_unit_tests:
+    needs:
+      - rubocop_and_matrix
     name: Unit tests on Windows with Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
@@ -93,6 +95,8 @@ jobs:
       - run: bundle exec rake spec_random
 
   acceptance_tests:
+    needs:
+      - rubocop_and_matrix
     name: Platform
     strategy:
       matrix:
@@ -152,6 +156,8 @@ jobs:
         run: ruby $Env:FACTER_ROOT/.github/actions/presuite.rb ${{ matrix.os }}
 
   integration_tests:
+    needs:
+      - rubocop_and_matrix
     name: Integration on ${{ matrix.cfg.os }} with Ruby ${{ matrix.cfg.ruby }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Our expensive jobs should depend on rubocop. It doesn't make sense to start the long running jobs if linting already fails.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
