### PR TITLE
Fix and improve timestamp formatting in logs

### DIFF
--- a/lib/facter/framework/logging/logger.rb
+++ b/lib/facter/framework/logging/logger.rb
@@ -52,7 +52,7 @@ module Facter
 
       def set_logger_format
         @@logger.formatter = proc do |severity, datetime, _progname, msg|
-          datetime = datetime.strftime('%Y-%m-%d %H:%M:%S.%6N')
+          datetime = datetime.strftime('%Y-%m-%dT%H:%M:%S.%6N%:z')
           "[#{datetime}] #{severity} #{msg} \n"
         end
       end

--- a/lib/facter/framework/logging/logger.rb
+++ b/lib/facter/framework/logging/logger.rb
@@ -52,7 +52,7 @@ module Facter
 
       def set_logger_format
         @@logger.formatter = proc do |severity, datetime, _progname, msg|
-          datetime = datetime.strftime(@datetime_format || '%Y-%m-%d %H:%M:%S.%6N ')
+          datetime = datetime.strftime('%Y-%m-%d %H:%M:%S.%6N')
           "[#{datetime}] #{severity} #{msg} \n"
         end
       end


### PR DESCRIPTION
Running with the `-d` flag, the timestamp unexpectedly ends with space:

```
[2026-07-31 05:13:44.249383 ] INFO Facter - executed with command line: virtual -d
                           ^ here
```

Remove that extra space.

While here, also remove this reference to @datetime_format which does
not exist anywhere else.
