### PR TITLE
Rebrand Puppet/Facter -> OpenVox/OpenFact in docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # How to contribute #
 
-Third-party patches are essential for keeping Puppet great. We simply can't access the huge number of platforms and myriad configurations for running Puppet. We want to keep it as easy as possible to contribute changes that get things working in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+Third-party patches are essential for keeping OpenVox great. We simply can't access the huge number of platforms and myriad configurations for running OpenVox. We want to keep it as easy as possible to contribute changes that get things working in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 
 ## Adding New Facts ##
 
 When adding new facts, they need to be added to the [schema](lib/schema/facter.yaml). The fact name, description, and type must be specified in the [schema](lib/schema/facter.yaml).
 
-Learn more about how to contribute in our [Contribution Guidelines](https://github.com/puppetlabs/.github/blob/main/CONTRIBUTING.md).
+Learn more about how to contribute in our [Contribution Documents](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md).

--- a/Extensibility.md
+++ b/Extensibility.md
@@ -1,7 +1,7 @@
 Extensibility
 =============
 
-Facter 4 has the following extensibility goals:
+OpenFact has the following extensibility goals:
 
 * Compatibility with 100% of existing Facter custom facts
 * Compatibility with 100% of existing Facter external facts
@@ -13,13 +13,13 @@ Note that this doc is work-in-progress and should be updated as extensibility fe
 Custom Facts Compatibility
 --------------------------
 
-Facter 4 will load custom facts from the following locations:
+OpenFact will load custom facts from the following locations:
 
 * Any Ruby source file in a `facter` subdirectory on the Ruby load path.
 * Any Ruby source file in a directory specified by the `FACTERLIB` environment variable (delimited by the platform PATH separator).
 * Any Ruby source file in a directory specified by the `--custom-dir` option to facter.
 
-The following methods from the Facter API are currently supported by Facter 4:
+The following methods from the Facter API are currently supported by OpenFact:
 
 From the `Facter` module:
 
@@ -81,12 +81,12 @@ From the `Facter::Core::Aggregate` module:
 * name
 * on_flush
 
-Please see the [Facter Custom Facts Walkthrough](https://puppet.com/docs/puppet/latest/custom_facts.html) for more information on using the Facter API.
+Please see the [Custom Facts Walkthrough](https://docs.openvoxproject.org/openfact/latest/custom_facts.html) for more information on using the Facter API.
 
 External Facts Compatiblity
 ---------------------------
 
-Facter 4 supports all 4 forms of "external facts" which Facter 3 supports:
+OpenFact supports all 4 forms of "external facts" which Facter 3 supports:
 * JSON files with the .json extension whose key-value pairs will be mapped to fact-value pairs.
 * YAML files with the .yaml extension whose key-value pairs will be mapped to fact-value pairs.
 * Text files with the .txt extension containing `fact=some_value` strings
@@ -95,7 +95,7 @@ Facter 4 supports all 4 forms of "external facts" which Facter 3 supports:
 Enable conversion of dotted facts to structured
 ---------------------------
 
-By default Facter 4 treats the `.` in custom or external fact names as part of the fact name and not a delimiter for structured facts.
+By default OpenFact treats the `.` in custom or external fact names as part of the fact name and not a delimiter for structured facts.
 
 If you want to enable the new behaviour, that converts dotted facts to structured you need to set the following config:
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ used to inform conditional expressions in Puppet.
 
 ## Documentation
 
-Documentation for the Facter project can be found on the [Puppet Docs
-site](https://puppet.com/docs/puppet/latest/facter.html).
+Documentation for OpenFact can be found on the [OpenVox Docs
+site](https://docs.openvoxproject.org/openfact/latest/).
 
-At the time of writing, the OpenVoxProject does not have a documentation website.
-But your help is very welcome!
+Your help improving the documentation is very welcome!
 Reach out to the [Documentation Special Interest Group](https://github.com/voxpupuli/community-triage/wiki/SIG.Documentation) if you want to help.
 
 ## Supported platforms

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -6,7 +6,7 @@ Generally, facter loads fact definitions (`LoadedFact`) to determine all of the 
 
 The `QueryParser` parse both user queries `a.b` and `c` and matches each query against all LoadedFacts, returning an array of `SearchedFacts`. These are more like SearchableFacts, since they haven't been searched yet.
 
-Facter attempts to lookup the facts from the cache, otherwise it calls the `InternalFactManager` and `ExternalFactManager` to resolve facts.
+OpenFact attempts to lookup the facts from the cache, otherwise it calls the `InternalFactManager` and `ExternalFactManager` to resolve facts.
 
 For internal facts, facter wraps each `SearchedFact` with a `CoreFact`. The `CoreFact` calls the `call_the_resolver` method on the class that the `SearchedFact` references. The `call_the_resolver` method then typically delegates to a resolver and returns the fact value which may be scalar or structured data. For example, `os.family` returns a string, but `gce` returns a Hash.
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,9 +1,9 @@
 ---
 project: 'facter'
-author: 'Puppet Labs'
-email: 'team-nw@puppet.com'
-homepage: 'https://github.com/puppetlabs/facter'
-summary: 'Facter, a system inventory tool'
+author: 'OpenVox Project'
+email: 'openvox@voxpupuli.org'
+homepage: 'https://github.com/OpenVoxProject/openfact'
+summary: 'OpenFact, a system inventory tool'
 description: 'You can prove anything with facts!'
 version_file: 'lib/facter/version.rb'
 files: 'bin/facter lib/facter.rb lib/**/*.rb'

--- a/lib/docs/template.erb
+++ b/lib/docs/template.erb
@@ -11,7 +11,7 @@
 ### `<%= name %>`
 
 <% if schema['hidden'] -%>
-This legacy fact is hidden by default in Facter's command-line output.
+This legacy fact is hidden by default in OpenFact's command-line output.
 
 <% end -%>
 **Type:** <%= schema['type'] %>

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -15,7 +15,7 @@ module Facter
   @already_searched = {}
 
   class << self
-    # Method used by puppet-agent to retrieve facts
+    # Method used by openvox-agent to retrieve facts
     # @param args_as_string [string] facter cli arguments
     #
     # @return [Hash<String, Object>]
@@ -45,8 +45,8 @@ module Facter
       Hash[queried_facts(cli.args)]
     end
 
-    # Method used by cli to set puppet paths
-    # in order to retrieve puppet custom and external facts
+    # Method used by cli to set OpenVox paths
+    # in order to retrieve OpenVox custom and external facts
     #
     # @return nil
     #
@@ -54,7 +54,7 @@ module Facter
     def puppet_facts
       require 'puppet'
 
-      # don't allow puppet logger to be injected in Facter
+      # don't allow the OpenVox logger to be injected in OpenFact
       Options[:allow_external_loggers] = false
 
       Puppet.initialize_settings
@@ -69,7 +69,7 @@ module Facter
         end
       end
     rescue LoadError => e
-      logger.error("Could not load puppet gem, got #{e}")
+      logger.error("Could not load the openvox gem, got #{e}")
     end
 
     # Alias method for Facter.fact()
@@ -375,7 +375,7 @@ module Facter
     # @api public
     def to_hash
       log_blocked_facts
-      logger.debug("Facter version: #{Facter::VERSION}")
+      logger.debug("OpenFact version: #{Facter::VERSION}")
 
       resolved_facts = Facter::FactManager.instance.resolve_facts
       resolved_facts.reject! { |fact| fact.type == :custom && fact.value.nil? }
@@ -439,7 +439,7 @@ module Facter
       @already_searched[user_query]
     end
 
-    # Returns Facter version
+    # Returns OpenFact version
     #
     # @return [String] Current version
     #
@@ -456,7 +456,7 @@ module Facter
     def to_user_output(cli_options, *args)
       init_cli_options(cli_options)
       logger.info("executed with command line: #{ARGV.drop(1).join(' ')}")
-      logger.debug("Facter version: #{Facter::VERSION}")
+      logger.debug("OpenFact version: #{Facter::VERSION}")
       log_blocked_facts
       resolved_facts = resolve_facts_for_user_query(args)
       fact_formatter = Facter::FormatterFactory.build(Facter::Options.get)

--- a/lib/facter/custom_facts/util/directory_loader.rb
+++ b/lib/facter/custom_facts/util/directory_loader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# A Facter plugin that loads external facts.
+# An OpenFact plugin that loads external facts.
 #
 # Default Unix Directories:
 # /opt/puppetlabs/custom_facts/facts.d, /etc/custom_facts/facts.d, /etc/puppetlabs/custom_facts/facts.d

--- a/lib/facter/framework/cli/cli.rb
+++ b/lib/facter/framework/cli/cli.rb
@@ -104,7 +104,7 @@ module Facter
     class_option :puppet,
                  type: :boolean,
                  aliases: '-p',
-                 desc: 'Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.'
+                 desc: 'Load the OpenVox libraries, thus allowing OpenFact to load OpenVox-specific facts.'
 
     desc '--man', 'Display manual.', hide: true
     map ['--man'] => :man

--- a/lib/facter/framework/config/config_reader.rb
+++ b/lib/facter/framework/config/config_reader.rb
@@ -34,7 +34,7 @@ module Facter
       def refresh_config(config_path)
         @conf = File.readable?(config_path) ? Hocon.load(config_path) : {}
       rescue StandardError => e
-        log.warn("Facter failed to read config file #{config_path} with the following error: #{e.message}")
+        log.warn("OpenFact failed to read config file #{config_path} with the following error: #{e.message}")
         @conf = {}
       end
 

--- a/lib/facter/util/file_helper.rb
+++ b/lib/facter/util/file_helper.rb
@@ -26,8 +26,8 @@ module Facter
 
         # This previously acted as a helper method for versions of Ruby older
         # than 2.5, before Dir.children was added. As it isn't a private
-        # method, we can't remove it entirely until the next major Facter
-        # release (presumably Facter 5).
+        # method, we can't remove it entirely until the next major OpenFact
+        # release.
         def dir_children(path)
           Dir.children(path)
         end

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -24,7 +24,7 @@
 
 aio_agent_version:
     type: string
-    description: Return the version of the puppet-agent package that installed facter.
+    description: Return the version of the openvox-agent package that installed facter.
     resolution: |
         All platforms: use the compile-time enabled version definition.
 
@@ -367,11 +367,11 @@ ec2_userdata:
 
 env_windows_installdir:
     type: string
-    description: Return the path of the directory in which Puppet was installed.
+    description: Return the path of the directory in which OpenVox was installed.
     resolution: |
       Windows: This fact is specific to the Windows MSI generated environment, and is
         set using the `environment.bat` script that configures the runtime environment
-        for all Puppet executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information.
+        for all OpenVox executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information.
     caveats: |
       This fact is specific to Windows, and will not resolve on any other platform.
 

--- a/man/man1/facter.1
+++ b/man/man1/facter.1
@@ -1,4 +1,4 @@
-.Dd Aug 22, 2025
+.Dd Aug 01, 2026
 .Dt FACTER 1
 .Os
 .Sh NAME
@@ -71,7 +71,7 @@ Resolve facts sequentially
 .It Fl Fl http-debug
 Whether to write HTTP request and responses to stderr. This should never be used in production.
 .It Fl p , Fl Fl puppet
-Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.
+Load the OpenVox libraries, thus allowing OpenFact to load OpenVox-specific facts.
 .El
 .Sh FILES
 .Bl -tag

--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -30,11 +30,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # While we require both ffi and sys-filesystem in parts of Facter, we specify
+  # While we require both ffi and sys-filesystem in parts of OpenFact, we specify
   # them as development, not runtime, dependencies. Both gems either directly
   # or indirectly contain native extensions. The intent behind excluding these
   # gems from runtime dependencies is to allow users to be able to install
-  # Facter without a compiler.
+  # OpenFact without a compiler.
   # ffi 1.16.0 - 1.16.2 are broken on Windows
   spec.add_development_dependency 'ffi', '>= 1.15.5', '< 1.18.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'

--- a/spec/framework/config/config_reader_spec.rb
+++ b/spec/framework/config/config_reader_spec.rb
@@ -151,7 +151,7 @@ describe Facter::ConfigReader do
       end
 
       it 'loggs a warning' do
-        expect(log).to receive(:warn).with(/Facter failed to read config file/)
+        expect(log).to receive(:warn).with(/OpenFact failed to read config file/)
 
         config_reader.init
       end

--- a/tasks/manpages.rake
+++ b/tasks/manpages.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-desc 'Build Facter manpages'
+desc 'Build OpenFact manpages'
 task :gen_manpages do
   require 'fileutils'
 


### PR DESCRIPTION
### Short description
Rebrand user-facing product references, following the treatment of OpenVoxProject/openvox#530:

- Facter -> OpenFact and Puppet -> OpenVox in README, Extensibility.md, docs/data-flow.md, code comments, docstrings, the --puppet CLI option description, fact schema descriptions, and log/warning message text (plus the matching spec expectation)
- puppet-agent -> openvox-agent where the AIO package is meant in prose
- Rewrite puppet.com documentation links to docs.openvoxproject.org
- Point CONTRIBUTING.md at the OpenVoxProject contribution documents
- Update author/email/homepage packaging metadata in ext/project_data.yaml to the OpenVox Project, matching openfact.gemspec
- Regenerate the man page with rake gen_manpages

Deliberately unchanged: the facter executable and man page command name, Facter/LegacyFacter Ruby namespaces and API, fact and resolver names, environment variables, file paths, registry keys, references to the Puppet language/DSL and manifests, comparisons with upstream Facter releases (Facter 3/4), copyright and license attributions, and CHANGELOG/HISTORY entries.

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
