### PR TITLE
bump rubocop to 1.90.0 and align lint-driven style updates

### DIFF
--- a/lib/facter/resolvers/solaris/ffi/structs.rb
+++ b/lib/facter/resolvers/solaris/ffi/structs.rb
@@ -10,20 +10,20 @@ module Facter
         end
 
         class Sockaddr < ::FFI::Struct
-          layout  :sa_family, :sa_family_t,
-                  :sa_data, [:uchar, 14]
+          layout :sa_family, :sa_family_t,
+                 :sa_data, [:uchar, 14]
         end
 
         class Lifnum < ::FFI::Struct
-          layout  :lifn_family, :sa_family_t,
-                  :lifn_flags, :int,
-                  :lifn_count, :int
+          layout :lifn_family, :sa_family_t,
+                 :lifn_flags, :int,
+                 :lifn_count, :int
         end
 
         class Arpreq < ::FFI::Struct
-          layout  :arp_pa, Sockaddr,
-                  :arp_ha, Sockaddr,
-                  :arp_flags, :int
+          layout :arp_pa, Sockaddr,
+                 :arp_ha, Sockaddr,
+                 :arp_flags, :int
 
           def sa_data_to_mac
             self[:arp_ha][:sa_data].entries[0, 6].map do |s|
@@ -41,27 +41,27 @@ module Facter
         end
 
         class Lifru1 < ::FFI::Union
-          layout  :lifru_addrlen, :int,
-                  :lifru_ppa, :uint_t
+          layout :lifru_addrlen, :int,
+                 :lifru_ppa, :uint_t
         end
 
         class Lifru < ::FFI::Union
-          layout  :lifru_addr, SockaddrStorage,
-                  :lifru_dstaddr, SockaddrStorage,
-                  :lifru_broadaddr, SockaddrStorage,
-                  :lifru_token, SockaddrStorage,
-                  :lifru_subnet, SockaddrStorage,
-                  :lifru_flags, :uint64,
-                  :lifru_metric, :int,
-                  :pad, [:char, 80]
+          layout :lifru_addr, SockaddrStorage,
+                 :lifru_dstaddr, SockaddrStorage,
+                 :lifru_broadaddr, SockaddrStorage,
+                 :lifru_token, SockaddrStorage,
+                 :lifru_subnet, SockaddrStorage,
+                 :lifru_flags, :uint64,
+                 :lifru_metric, :int,
+                 :pad, [:char, 80]
         end
 
         class Lifreq < ::FFI::Struct
-          layout  :lifr_name, [:char, 32],
-                  :lifr_lifru1, Lifru1,
-                  :lifr_movetoindex, :int,
-                  :lifr_lifru, Lifru,
-                  :pad, [:char, 80]
+          layout :lifr_name, [:char, 32],
+                 :lifr_lifru1, Lifru1,
+                 :lifr_movetoindex, :int,
+                 :lifr_lifru, Lifru,
+                 :pad, [:char, 80]
 
           def name
             self[:lifr_name].to_s
@@ -77,10 +77,10 @@ module Facter
         end
 
         class Lifconf < ::FFI::Struct
-          layout  :lifc_family, :uint,
-                  :lifc_flags, :int,
-                  :lifc_len, :int,
-                  :lifc_buf, :pointer
+          layout :lifc_family, :uint,
+                 :lifc_flags, :int,
+                 :lifc_len, :int,
+                 :lifc_buf, :pointer
 
           def self.new_for_ioctl(interface_count)
             lifconf = new
@@ -93,8 +93,8 @@ module Facter
         end
 
         class Lifcu < ::FFI::Union
-          layout  :lifcu_buf, :caddr_t,
-                  :lifcu_req, Lifreq
+          layout :lifcu_buf, :caddr_t,
+                 :lifcu_req, Lifreq
         end
 
         class InAddr < ::FFI::Struct
@@ -102,10 +102,10 @@ module Facter
         end
 
         class SockaddrIn < ::FFI::Struct
-          layout  :sin_family, :sa_family_t,
-                  :sin_port, :in_port_t,
-                  :sin_addr, InAddr,
-                  :sin_zero, [:char, 8]
+          layout :sin_family, :sa_family_t,
+                 :sin_port, :in_port_t,
+                 :sin_addr, InAddr,
+                 :sin_zero, [:char, 8]
 
           def s_addr
             self[:sin_addr][:s_addr]
@@ -117,11 +117,11 @@ module Facter
         end
 
         class SockaddrIn6 < ::FFI::Struct
-          layout  :sin6_family, :sa_family_t,
-                  :sin6_port, :in_port_t,
-                  :sin6_flowinfo, :uint32_t,
-                  :sin6_addr, In6Addr,
-                  :sin6_scope_id, :uint32_t
+          layout :sin6_family, :sa_family_t,
+                 :sin6_port, :in_port_t,
+                 :sin6_flowinfo, :uint32_t,
+                 :sin6_addr, In6Addr,
+                 :sin6_scope_id, :uint32_t
         end
       end
     end

--- a/lib/facter/resolvers/windows/netkvm.rb
+++ b/lib/facter/resolvers/windows/netkvm.rb
@@ -23,9 +23,8 @@ module Facter
         end
 
         def build_fact_list(reg)
-          # rubocop:disable Performance/InefficientHashSearch
+          # rubocop:disable-next Performance/InefficientHashSearch
           @fact_list[:kvm] = reg.keys.include?('netkvm')
-          # rubocop:enable Performance/InefficientHashSearch
         end
       end
     end

--- a/lib/facter/util/file_helper.rb
+++ b/lib/facter/util/file_helper.rb
@@ -15,14 +15,13 @@ module Facter
           default_return
         end
 
-        # rubocop:disable Style/SpecialGlobalVars
+        # rubocop:disable-next Style/SpecialGlobalVars
         def safe_readlines(path, default_return = [], sep = $/, chomp: false)
           return File.readlines(path, sep, chomp: chomp, encoding: Encoding::UTF_8) if File.readable?(path)
 
           log_failed_to_read(path)
           default_return
         end
-        # rubocop:enable Style/SpecialGlobalVars
 
         # This previously acted as a helper method for versions of Ruby older
         # than 2.5, before Dir.children was added. As it isn't a private

--- a/openfact.gemspec
+++ b/openfact.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ffi', '>= 1.15.5', '< 1.18.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 1.89.0'
+  spec.add_development_dependency 'rubocop', '~> 1.90.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5'
   spec.add_development_dependency 'rubocop-rake', '< 1'
   spec.add_development_dependency 'rubocop-rspec', '>= 2.10', '< 4'

--- a/spec/facter/util/file_helper_spec.rb
+++ b/spec/facter/util/file_helper_spec.rb
@@ -6,9 +6,8 @@ describe Facter::Util::FileHelper do
   let(:path) { '/Users/admin/file.txt' }
   let(:entries) { ['file.txt', 'a'] }
   let(:content) { 'file content' }
-  # rubocop:disable Style/SpecialGlobalVars
+  # rubocop:disable-next Style/SpecialGlobalVars
   let(:sep) { $/ }
-  # rubocop:enable Style/SpecialGlobalVars
   let(:error_message) do
     "Facter::Util::FileHelper - #{Facter::CYAN}File at: /Users/admin/file.txt is not accessible.#{Facter::RESET}"
   end

--- a/spec/framework/core/options/options_validator_spec.rb
+++ b/spec/framework/core/options/options_validator_spec.rb
@@ -54,12 +54,11 @@ describe Facter::OptionsValidator do
     end
 
     context 'when parsing resolved options' do
-      # rubocop:disable Style/BlockDelimiters
+      # rubocop:disable-next Style/BlockDelimiters
       let(:options) {
         { puppet: true, external_facts: false, external_dir: Facter::OptionStore.default_external_dir + [''],
           ruby: true, custom_facts: true }
       }
-      # rubocop:enable Style/BlockDelimiters
 
       it 'writes message and exit' do
         stub_const('Puppet', { pluginfactdest: '' })


### PR DESCRIPTION
- Upgrade rubocop development dependency from 1.89.0 to 1.90.0
- Replace single-statement disable/enable directive pairs with `rubocop:disable-next` to satisfy newer directive scope checks
- Apply RuboCop layout spacing normalization in Solaris FFI struct definitions

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
