### PR TITLE
Reject partial EC2 metadata results

### DIFF
--- a/lib/facter/resolvers/ec2.rb
+++ b/lib/facter/resolvers/ec2.rb
@@ -18,14 +18,19 @@ module Facter
         end
 
         def read_facts(fact_name)
-          @fact_list[:metadata] = {}
-          query_for_metadata(EC2_METADATA_ROOT_URL, @fact_list[:metadata])
-          @fact_list[:userdata] = get_data_from(EC2_USERDATA_ROOT_URL).strip.force_encoding('UTF-8')
+          if fact_name == :metadata
+            metadata = {}
+            query_for_metadata(EC2_METADATA_ROOT_URL, metadata)
+            @fact_list[:metadata] = metadata
+          else
+            @fact_list[:userdata] = get_data_from(EC2_USERDATA_ROOT_URL).strip.force_encoding('UTF-8')
+          end
+
           @fact_list[fact_name]
         end
 
         def query_for_metadata(url, container)
-          metadata = get_data_from(url)
+          metadata = get_metadata_from(url)
           metadata.each_line do |line|
             next if line.empty?
 
@@ -34,14 +39,15 @@ module Facter
 
             if http_path_component.end_with?('/')
               child = {}
-              child[http_path_component] = query_for_metadata("#{url}#{http_path_component}", child)
-              child.reject! { |key, _info| key == http_path_component }
+              query_for_metadata("#{url}#{http_path_component}", child)
               name = http_path_component.chomp('/')
               container[name] = child
             else
-              container[http_path_component] = get_data_from("#{url}#{http_path_component}").strip
+              container[http_path_component] = get_metadata_from("#{url}#{http_path_component}").strip
             end
           end
+
+          container
         end
 
         def build_path_component(line)
@@ -53,6 +59,12 @@ module Facter
           headers = {}
           headers['X-aws-ec2-metadata-token'] = v2_token if v2_token
           Facter::Util::Resolvers::Http.get_request(url, headers, { session: determine_session_timeout }, false)
+        end
+
+        def get_metadata_from(url)
+          headers = {}
+          headers['X-aws-ec2-metadata-token'] = v2_token if v2_token
+          Facter::Util::Resolvers::Http.get_request!(url, headers, { session: determine_session_timeout }, false)
         end
 
         def determine_session_timeout

--- a/lib/facter/util/resolvers/http.rb
+++ b/lib/facter/util/resolvers/http.rb
@@ -6,6 +6,8 @@ module Facter
       module Http
         @log = Facter::Log.new(self)
 
+        class RequestError < StandardError; end
+
         class << self
           CONNECTION_TIMEOUT = 0.6
           SESSION_TIMEOUT = 5
@@ -27,6 +29,15 @@ module Facter
             make_request(url, headers, timeouts, 'GET', proxy)
           end
 
+          # Makes a GET HTTP request and returns its response body.
+          #
+          # Unlike get_request, this method raises when the response code is
+          # not 200 or when the request fails. A successful empty response is
+          # still returned as an empty string.
+          def get_request!(url, headers = {}, timeouts = {}, proxy = true)
+            make_request!(url, headers, timeouts, 'GET', proxy)
+          end
+
           # Makes a PUT HTTP request and returns its response
           # @param (see #get_request)
           # @return (see #get_request)
@@ -37,6 +48,28 @@ module Facter
           private
 
           def make_request(url, headers, timeouts, request_type, proxy)
+            response = perform_request(url, headers, timeouts, request_type, proxy)
+
+            successful_response?(response) ? response.body : ''
+          rescue StandardError => e
+            @log.debug("Trying to connect to #{url} but got: #{e.message}")
+            ''
+          end
+
+          def make_request!(url, headers, timeouts, request_type, proxy)
+            response = perform_request(url, headers, timeouts, request_type, proxy)
+
+            return response.body if successful_response?(response)
+
+            raise RequestError, "Request to #{url} failed with HTTP status #{response.code}"
+          rescue RequestError
+            raise
+          rescue StandardError => e
+            @log.debug("Trying to connect to #{url} but got: #{e.message}")
+            raise
+          end
+
+          def perform_request(url, headers, timeouts, request_type, proxy)
             require 'net/http'
 
             uri = URI.parse(url)
@@ -52,11 +85,7 @@ module Facter
             # Make the request
             response = http.request(request)
             response.uri = url
-
-            successful_response?(response) ? response.body : ''
-          rescue StandardError => e
-            @log.debug("Trying to connect to #{url} but got: #{e.message}")
-            ''
+            response
           end
 
           def http_obj(parsed_url, timeouts, proxy)

--- a/spec/facter/resolvers/ec2_spec.rb
+++ b/spec/facter/resolvers/ec2_spec.rb
@@ -49,6 +49,12 @@ describe Facter::Resolvers::Ec2 do
         expect(ec2.resolve(:userdata)).to eql('userdata')
       end
 
+      it 'does not fetch userdata while resolving metadata' do
+        ec2.resolve(:metadata)
+
+        expect(a_request(:get, userdata_uri)).not_to have_been_made
+      end
+
       it 'parses ec2 network/ directory as a multi-level hash' do
         network_hash = {
           'network' => {
@@ -81,8 +87,8 @@ describe Facter::Resolvers::Ec2 do
         expect(ec2.resolve(:metadata)).to match(hash_including(network_hash))
       end
 
-      it 'fetches the available data' do
-        stub_request(:get, "#{metadata_uri}instance_type").with(headers: headers).to_return(status: 404)
+      it 'preserves a successful empty value' do
+        stub_request(:get, "#{metadata_uri}instance_type").with(headers: headers).to_return(status: 200, body: '')
 
         expect(ec2.resolve(:metadata)).to match(
           {
@@ -92,6 +98,20 @@ describe Facter::Resolvers::Ec2 do
           }
         )
       end
+
+      it 'rejects all metadata when one request is unsuccessful' do
+        stub_request(:get, "#{metadata_uri}instance_type").with(headers: headers).to_return(status: 404)
+
+        expect { ec2.resolve(:metadata) }.to raise_error(Facter::Util::Resolvers::Http::RequestError)
+        expect(ec2.instance_variable_get(:@fact_list)).not_to have_key(:metadata)
+      end
+
+      it 'rejects all metadata when one request times out' do
+        stub_request(:get, "#{metadata_uri}instance_type").with(headers: headers).to_timeout
+
+        expect { ec2.resolve(:metadata) }.to raise_error(Timeout::Error)
+        expect(ec2.instance_variable_get(:@fact_list)).not_to have_key(:metadata)
+      end
     end
 
     context 'when an exception is thrown' do
@@ -100,8 +120,9 @@ describe Facter::Resolvers::Ec2 do
         stub_request(:get, metadata_uri).to_raise(StandardError)
       end
 
-      it 'returns empty ec2 metadata' do
-        expect(ec2.resolve(:metadata)).to eql({})
+      it 'does not return partial ec2 metadata' do
+        expect { ec2.resolve(:metadata) }.to raise_error(StandardError)
+        expect(ec2.instance_variable_get(:@fact_list)).not_to have_key(:metadata)
       end
 
       it 'returns empty ec2 userdata' do

--- a/spec/facter/util/resolvers/http_spec.rb
+++ b/spec/facter/util/resolvers/http_spec.rb
@@ -146,6 +146,48 @@ describe Facter::Util::Resolvers::Http do
     it_behaves_like 'an http request'
   end
 
+  describe '#get_request!' do
+    context 'when successful' do
+      it 'returns the response body' do
+        stub_request(:get, url).to_return(status: 200, body: 'success')
+
+        expect(http.get_request!(url)).to eql('success')
+      end
+
+      it 'preserves an empty response body' do
+        stub_request(:get, url).to_return(status: 200, body: '')
+
+        expect(http.get_request!(url)).to eql('')
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      it 'raises a request error' do
+        stub_request(:get, url).to_return(status: 503, body: 'Service Unavailable')
+
+        expect { http.get_request!(url) }
+          .to raise_error(Facter::Util::Resolvers::Http::RequestError, /HTTP status 503/)
+      end
+    end
+
+    context 'when the request times out' do
+      it 'propagates the timeout' do
+        stub_request(:get, url).to_timeout
+
+        expect { http.get_request!(url) }.to raise_error(Timeout::Error)
+      end
+    end
+
+    context 'when the HTTP request raises an error' do
+      it 'propagates the error' do
+        error = StandardError.new('some error')
+        stub_request(:get, url).to_raise(error)
+
+        expect { http.get_request!(url) }.to raise_error(error)
+      end
+    end
+  end
+
   describe '#put_request' do
     let(:http_verb) { :put }
     let(:client_method) { :put_request }


### PR DESCRIPTION
Resolve EC2 metadata with strict HTTP requests so a timeout, transport exception, or non-200 response aborts the entire recursive lookup. Build metadata separately and publish it only after every request succeeds. Previously, the shared HTTP helper converted failures to empty strings, making them indistinguishable from successful empty responses and allowing partially populated metadata to be cached.

Keep successful 200 responses with empty bodies unchanged. Preserve the existing lenient HTTP helper for other callers, userdata behavior, and the EC2 cache lifetime.

Add regression coverage for successful empty values, failed child requests, timeouts, and atomic publication.

Assisted-by: OpenAI Codex:GPT-5


Fixes https://github.com/OpenVoxProject/openfact/issues/175

### Checklist

I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
