### PR TITLE
Bound the fqdn lookup in the hostname resolvers

### DIFF
--- a/lib/facter/resolvers/hostname.rb
+++ b/lib/facter/resolvers/hostname.rb
@@ -9,6 +9,11 @@ module Facter
 
       init_resolver
 
+      # Upper bound, in seconds, for the fqdn lookup. A hung name service
+      # otherwise stalls fact collection until the agent's runtimeout fires
+      # (OpenVoxProject/openvox#485). Only applied on Rubies that honour it.
+      FQDN_LOOKUP_TIMEOUT = 10
+
       class << self
         private
 
@@ -48,14 +53,27 @@ module Facter
 
         def retrieve_with_addrinfo(host)
           begin
-            name = Socket.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)[0]
+            addr = Addrinfo.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME,
+                                        **addrinfo_options)[0]
           rescue StandardError => e
-            @log.debug("Socket.getaddrinfo failed to retrieve fqdn for hostname #{host} with: #{e}")
+            @log.debug("Addrinfo.getaddrinfo failed to retrieve fqdn for hostname #{host} with: #{e}")
             return
           end
-          return if name.nil? || name.empty? || host == name[2] || name[2] == name[3]
 
-          name[2]
+          name = addr&.canonname
+          return if name.nil? || name.empty? || host == name || name == addr.ip_address
+
+          name
+        end
+
+        # Addrinfo.getaddrinfo only honours the timeout keyword from Ruby 4.0
+        # on. Older MRI accepts and ignores it; JRuby does not accept it.
+        def addrinfo_options
+          addrinfo_timeout_supported? ? { timeout: FQDN_LOOKUP_TIMEOUT } : {}
+        end
+
+        def addrinfo_timeout_supported?
+          RUBY_ENGINE == 'ruby' && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0')
         end
 
         def exists_and_valid_fqdn?(fqdn, hostname)

--- a/lib/facter/resolvers/linux/hostname.rb
+++ b/lib/facter/resolvers/linux/hostname.rb
@@ -10,6 +10,11 @@ module Facter
 
         init_resolver
 
+        # Upper bound, in seconds, for the fqdn lookup. A hung name service
+        # otherwise stalls fact collection until the agent's runtimeout fires
+        # (OpenVoxProject/openvox#485). Only applied on Rubies that honour it.
+        FQDN_LOOKUP_TIMEOUT = 10
+
         class << self
           private
 
@@ -65,14 +70,33 @@ module Facter
 
           def retrieve_fqdn_for_host(host)
             begin
-              name = Socket.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)[0]
+              addr = Addrinfo.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME,
+                                          **addrinfo_options)[0]
             rescue StandardError => e
-              log.debug("Socket.getaddrinfo failed to retrieve fqdn for hostname #{host} with: #{e}")
+              log.debug("Addrinfo.getaddrinfo failed to retrieve fqdn for hostname #{host} with: #{e}")
+              # The name service is not answering. The FFI lookup below has no
+              # timeout and holds the GVL while it waits, so do not try it.
+              return if lookup_timed_out?(e)
             end
 
-            return name[2] if !name.nil? && !name.empty? && host != name[2] && name[2] != name[3]
+            name = addr&.canonname
+            return name if exists_and_not_empty?(name) && host != name && name != addr.ip_address
 
             retrieve_fqdn_for_host_with_ffi(host)
+          end
+
+          def lookup_timed_out?(error)
+            error.is_a?(Errno::ETIMEDOUT) || (defined?(IO::TimeoutError) && error.is_a?(IO::TimeoutError))
+          end
+
+          # Addrinfo.getaddrinfo only honours the timeout keyword from Ruby 4.0
+          # on. Older MRI accepts and ignores it; JRuby does not accept it.
+          def addrinfo_options
+            addrinfo_timeout_supported? ? { timeout: FQDN_LOOKUP_TIMEOUT } : {}
+          end
+
+          def addrinfo_timeout_supported?
+            RUBY_ENGINE == 'ruby' && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0')
           end
 
           def retrieve_fqdn_for_host_with_ffi(host)

--- a/spec/facter/resolvers/hostname_spec.rb
+++ b/spec/facter/resolvers/hostname_spec.rb
@@ -41,7 +41,7 @@ describe Facter::Resolvers::Hostname do
       let(:fqdn) { "#{hostname}.#{domain}" }
 
       before do
-        allow(Socket).to receive(:getaddrinfo).and_return(domain)
+        allow(Addrinfo).to receive(:getaddrinfo).and_return([])
       end
 
       it 'detects hostname' do
@@ -54,6 +54,61 @@ describe Facter::Resolvers::Hostname do
 
       it 'returns fqdn' do
         expect(hostname_resolver.resolve(:fqdn)).to eq(fqdn)
+      end
+    end
+
+    context 'when hostname returns host and addrinfo returns the fqdn' do
+      let(:hostname) { 'foo' }
+      let(:domain) { 'bar' }
+      let(:host) { hostname }
+      let(:fqdn) { "#{hostname}.#{domain}" }
+
+      before do
+        allow(Addrinfo).to receive(:getaddrinfo)
+          .and_return([instance_double(Addrinfo, canonname: fqdn, ip_address: '10.0.0.1')])
+      end
+
+      it 'bounds the lookup with a timeout when Ruby honours it' do
+        stub_const('RUBY_ENGINE', 'ruby')
+        stub_const('RUBY_VERSION', '4.0.0')
+
+        hostname_resolver.resolve(:fqdn)
+
+        expect(Addrinfo).to have_received(:getaddrinfo)
+          .with(hostname, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME,
+                timeout: Facter::Resolvers::Hostname::FQDN_LOOKUP_TIMEOUT)
+      end
+
+      it 'omits the timeout when Ruby does not honour it' do
+        stub_const('RUBY_ENGINE', 'ruby')
+        stub_const('RUBY_VERSION', '3.4.0')
+
+        hostname_resolver.resolve(:fqdn)
+
+        expect(Addrinfo).to have_received(:getaddrinfo)
+          .with(hostname, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)
+      end
+
+      it 'returns networking Domain' do
+        expect(hostname_resolver.resolve(:domain)).to eq(domain)
+      end
+
+      it 'returns fqdn' do
+        expect(hostname_resolver.resolve(:fqdn)).to eq(fqdn)
+      end
+    end
+
+    context 'when hostname returns host and addrinfo times out' do
+      let(:host) { 'foo' }
+
+      let(:timeout_error) { defined?(IO::TimeoutError) ? IO::TimeoutError : Errno::ETIMEDOUT }
+
+      before do
+        allow(Addrinfo).to receive(:getaddrinfo).and_raise(timeout_error, 'user specified timeout')
+      end
+
+      it 'detects domain from resolv.conf' do
+        expect(hostname_resolver.resolve(:domain)).to eq('baz')
       end
     end
 
@@ -71,7 +126,7 @@ describe Facter::Resolvers::Hostname do
 
       before do
         allow(Facter::Util::FileHelper).to receive(:safe_read).with('/etc/resolv.conf').and_return('')
-        allow(Socket).to receive(:getaddrinfo).and_return(domain)
+        allow(Addrinfo).to receive(:getaddrinfo).and_return([])
       end
 
       it 'detects that domain is nil' do
@@ -83,7 +138,7 @@ describe Facter::Resolvers::Hostname do
       let(:host) { 'foo' }
 
       before do
-        allow(Socket).to receive(:getaddrinfo).and_raise('socket exception')
+        allow(Addrinfo).to receive(:getaddrinfo).and_raise('socket exception')
       end
 
       it 'detects domain from resolv.conf' do

--- a/spec/facter/resolvers/linux/hostname_spec.rb
+++ b/spec/facter/resolvers/linux/hostname_spec.rb
@@ -42,10 +42,50 @@ describe Facter::Resolvers::Linux::Hostname do
 
       context 'when it returns only the hostname and ruby addrinfo works' do
         let(:host) { hostname }
-        let(:addr_info) { [['', '', "#{hostname}.#{domain}", '']] }
+        let(:addr_info) { [instance_double(Addrinfo, canonname: "#{hostname}.#{domain}", ip_address: '10.0.0.1')] }
 
         before do
-          allow(Socket).to receive(:getaddrinfo).and_return(addr_info)
+          allow(Addrinfo).to receive(:getaddrinfo).and_return(addr_info)
+        end
+
+        it_behaves_like 'detects values'
+      end
+
+      context 'when it returns only the hostname and ruby addrinfo times out' do
+        let(:host) { hostname }
+        let(:domain) { 'baz' }
+        let(:timeout_error) { defined?(IO::TimeoutError) ? IO::TimeoutError : Errno::ETIMEDOUT }
+
+        before do
+          allow(Addrinfo).to receive(:getaddrinfo).and_raise(timeout_error, 'user specified timeout')
+          allow(Facter::Util::Resolvers::Ffi::Hostname).to receive(:getffiaddrinfo)
+        end
+
+        it 'bounds the lookup with a timeout when Ruby honours it' do
+          stub_const('RUBY_ENGINE', 'ruby')
+          stub_const('RUBY_VERSION', '4.0.0')
+
+          hostname_resolver.resolve(:fqdn)
+
+          expect(Addrinfo).to have_received(:getaddrinfo)
+            .with(hostname, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME,
+                  timeout: Facter::Resolvers::Linux::Hostname::FQDN_LOOKUP_TIMEOUT)
+        end
+
+        it 'omits the timeout when Ruby does not honour it' do
+          stub_const('RUBY_ENGINE', 'ruby')
+          stub_const('RUBY_VERSION', '3.4.0')
+
+          hostname_resolver.resolve(:fqdn)
+
+          expect(Addrinfo).to have_received(:getaddrinfo)
+            .with(hostname, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)
+        end
+
+        it 'does not fall back to the FFI lookup' do
+          hostname_resolver.resolve(:fqdn)
+
+          expect(Facter::Util::Resolvers::Ffi::Hostname).not_to have_received(:getffiaddrinfo)
         end
 
         it_behaves_like 'detects values'
@@ -56,7 +96,7 @@ describe Facter::Resolvers::Linux::Hostname do
         let(:output) { fqdn }
 
         before do
-          allow(Socket).to receive(:getaddrinfo).and_return([])
+          allow(Addrinfo).to receive(:getaddrinfo).and_return([])
           allow(Facter::Util::Resolvers::Ffi::Hostname).to receive(:getffiaddrinfo).and_return(output)
         end
 
@@ -153,11 +193,11 @@ describe Facter::Resolvers::Linux::Hostname do
       end
 
       context 'when it returns only the hostname and ruby addrinfo works' do
-        let(:addr_info) { [['', '', "#{hostname}.#{domain}", '']] }
+        let(:addr_info) { [instance_double(Addrinfo, canonname: "#{hostname}.#{domain}", ip_address: '10.0.0.1')] }
         let(:ffi_host) { hostname }
 
         before do
-          allow(Socket).to receive(:getaddrinfo).and_return(addr_info)
+          allow(Addrinfo).to receive(:getaddrinfo).and_return(addr_info)
         end
 
         it_behaves_like 'detects values'
@@ -168,7 +208,7 @@ describe Facter::Resolvers::Linux::Hostname do
         let(:output) { fqdn }
 
         before do
-          allow(Socket).to receive(:getaddrinfo).and_return([])
+          allow(Addrinfo).to receive(:getaddrinfo).and_return([])
           allow(Facter::Util::Resolvers::Ffi::Hostname).to receive(:getffiaddrinfo).and_return(output)
         end
 


### PR DESCRIPTION
### Short description
When the short hostname carries no domain, the hostname resolvers ask the name service for the canonical name with getaddrinfo(3). That call had no upper bound, so a hung resolver stalled fact collection until the agent's runtimeout fired an hour later (OpenVoxProject/openvox#485).

Switch to Addrinfo.getaddrinfo and pass a 10 second timeout on Rubies that honour it (MRI 4.0 and later; older MRI accepts and ignores the keyword, JRuby does not accept it, so it is omitted there). On Linux, a timed-out lookup no longer falls through to the FFI getaddrinfo fallback, which has no timeout of its own and holds the GVL while it waits. The domain then comes from /etc/resolv.conf as it already does when the lookup fails.

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
